### PR TITLE
 Prefix for service index name

### DIFF
--- a/docs/setup-indexer.md
+++ b/docs/setup-indexer.md
@@ -21,6 +21,9 @@ OPENSEARCH_PORT=9200
 
 # Enable SSL for opensearch connection (False in dev mode)
 OPENSEARCH_USE_SSL=True
+
+# Prefix for the index name of the registered services.
+OPENSEARCH_INDEX_PREFIX=find
 ```
 
 ### Semantic search

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -15,6 +15,7 @@ FIND_BASE_URL="http://localhost:8072"
 # Opensearch
 OPENSEARCH_PASSWORD=find.PASS123
 OPENSEARCH_USE_SSL=false
+OPENSEARCH_INDEX_PREFIX=find
 
 # OIDC
 OIDC_OP_JWKS_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/certs

--- a/src/backend/core/tests/utils.py
+++ b/src/backend/core/tests/utils.py
@@ -36,6 +36,9 @@ def enable_hybrid_search(settings):
     settings.EMBEDDING_REQUEST_TIMEOUT = 10
     settings.EMBEDDING_API_MODEL_NAME = "embeddings-small"
     settings.EMBEDDING_DIMENSION = 1024
+
+    # Clear the cache here or the hybrid search will remain disabled
+    check_hybrid_search_enabled.cache_clear()
     ensure_search_pipeline_exists()
 
 


### PR DESCRIPTION
Service opensearch index is now defined by the property 'index_name' and prefixed by the new setting OPENSEARCH_INDEX_PREFIX

Fix issue https://github.com/suitenumerique/find/issues/19
