### PR TITLE
🐛(sentry) normalize the setting and update code

### DIFF
--- a/src/backend/find/settings.py
+++ b/src/backend/find/settings.py
@@ -19,6 +19,7 @@ from django.utils.translation import gettext_lazy as _
 import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -324,7 +325,7 @@ class Base(Configuration):
     CORS_ALLOWED_ORIGIN_REGEXES = values.ListValue([])
 
     # Sentry
-    SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
+    SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN", environ_prefix=None)
 
     # Celery
     CELERY_BROKER_URL = values.Value("redis://redis:6379/0")
@@ -530,8 +531,11 @@ class Base(Configuration):
                 release=get_release(),
                 integrations=[DjangoIntegration()],
             )
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_extra("application", "backend")
+            scope = sentry_sdk.get_current_scope()
+            scope.set_extra("application", "backend")
+
+            # Ignore the logs added by the DockerflowMiddleware
+            ignore_logger("request.summary")
 
 
 class Build(Base):


### PR DESCRIPTION
## Purpose

This commit makes the Sentry setting to be like other project (ie without the DJANGO_ prefix) and update deprecated scope definition.


