### PR TITLE
👷(docker) add arm64 platform support for image builds

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -22,6 +22,12 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v4
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -44,6 +50,7 @@ jobs:
         with:
           context: .
           target: backend-production
+          platforms: linux/amd64,linux/arm64
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- 👷(docker) add arm64 platform support for image builds
 - ✨(backend) add semantic search
 - ✨(backend) add multi-embedding and chunking
 - ✨(backend) add analyzers to full-text search


### PR DESCRIPTION
## Purpose / Proposal

Adding support for `linux/arm64` when building Docker images.

This is important because:

1. It enables to run La Suite on devices like the Raspberry Pi and Mac Mini. It will also make it easier for developers to contribute, as many are using Apple MacBooks with arm64 chips.
2. More and more providers (such as Hetzner) for infrastructure are offering arm64 support.
3. Sustainability is a point of interest (and sometimes condition) for organizations, commercially but specifically also governments, when they are buying infrastructure.

## External contributions

- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)

Testing happens when GitHub Workflows are being executed.