### PR TITLE
Fix search type value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@ and this project adheres to
 
 - 🐛(backend) fix missing index creation in 'index/' view
 - 🐛(backend) fix parallel test execution issues
+- 🐛(backend) fix search type value #68

--- a/src/backend/core/enums.py
+++ b/src/backend/core/enums.py
@@ -20,7 +20,7 @@ class SearchTypeEnum(str, Enum):
     """Search type options"""
 
     HYBRID = "hybrid"
-    FULL_TEXT = "full_text"
+    FULL_TEXT = "full-text"
 
 
 # Fields

--- a/src/backend/core/schemas.py
+++ b/src/backend/core/schemas.py
@@ -18,7 +18,7 @@ from pydantic import (
 )
 
 from . import enums
-from .enums import SearchTypeEnum
+from .services.opensearch import check_hybrid_search_enabled
 
 
 class DocumentSchema(BaseModel):
@@ -119,7 +119,22 @@ class SearchQueryParametersSchema(BaseModel):
     order_by: Optional[Literal[enums.ORDER_BY_OPTIONS]] = Field(default=enums.RELEVANCE)
     order_direction: Optional[Literal["asc", "desc"]] = Field(default="desc")
     nb_results: Optional[conint(ge=1, le=300)] = Field(default=50)
-    search_type: Optional[SearchTypeEnum] = Field(default=None)
+    search_type: Optional[enums.SearchTypeEnum] = None
+
+    @model_validator(mode="after")
+    def set_default_search_type(self):
+        """
+        Set default search_type dynamically.
+        If search_type is not provided, it will be set to hybrid if it is configured
+        and fall back on full text otherwise.
+        """
+        if self.search_type is None:
+            self.search_type = (
+                enums.SearchTypeEnum.HYBRID
+                if check_hybrid_search_enabled()
+                else enums.SearchTypeEnum.FULL_TEXT
+            )
+        return self
 
 
 class DeleteDocumentsSchema(BaseModel):

--- a/src/backend/core/services/indexing.py
+++ b/src/backend/core/services/indexing.py
@@ -56,19 +56,17 @@ def ensure_index_exists(index_name):
 def prepare_document_for_indexing(document):
     """Prepare document for indexing using nested language structure and handle embedding"""
     language_code = detect_language_code(f"{document['title']} {document['content']}")
+    chunks = (
+        chunk_document(document["title"], document["content"])
+        if check_hybrid_search_enabled()
+        else None
+    )
     return {
         "id": document["id"],
         f"title.{language_code}": document["title"],
         f"content.{language_code}": document["content"],
-        "embedding_model": settings.EMBEDDING_API_MODEL_NAME
-        if check_hybrid_search_enabled()
-        else None,
-        "chunks": chunk_document(
-            document["title"],
-            document["content"],
-        )
-        if check_hybrid_search_enabled()
-        else None,
+        "chunks": chunks,
+        "embedding_model": settings.EMBEDDING_API_MODEL_NAME if chunks else None,
         "depth": document["depth"],
         "path": document["path"],
         "numchild": document["numchild"],

--- a/src/backend/core/tests/test_api_documents_search.py
+++ b/src/backend/core/tests/test_api_documents_search.py
@@ -94,7 +94,7 @@ def test_api_documents_search_opensearch_env_variables_not_set(settings):
 
 @responses.activate
 def test_api_documents_search_query_unknown_user(settings):
-    """Searching a document without an existing user should result in a 401 error"""
+    """Searching a document without an existing user should result in a 400 error"""
     setup_oicd_resource_server(
         responses,
         settings,

--- a/src/backend/core/views.py
+++ b/src/backend/core/views.py
@@ -12,14 +12,13 @@ from rest_framework.response import Response
 
 from . import schemas
 from .authentication import ServiceTokenAuthentication
-from .enums import SearchTypeEnum
 from .permissions import IsAuthAuthenticated
 from .services.indexing import (
     ensure_index_exists,
     get_opensearch_indices,
     prepare_document_for_indexing,
 )
-from .services.opensearch import check_hybrid_search_enabled, opensearch_client
+from .services.opensearch import opensearch_client
 from .services.search import search
 from .utils import get_language_value
 
@@ -306,7 +305,6 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
         - The search results can be sorted or filtered via querystring parameters.
     """
 
-    authentication_classes = [ResourceServerAuthentication]
     permission_classes = [IsAuthAuthenticated]
 
     def post(self, request, *args, **kwargs):
@@ -365,7 +363,13 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
         audience = self._get_service_provider_audience()
         user_sub = self.request.user.sub
         groups = []
-        params = schemas.SearchQueryParametersSchema(**request.data)
+
+        try:
+            params = schemas.SearchQueryParametersSchema(**request.data)
+        except PydanticValidationError as excpt:
+            errors = {error["loc"][0]: error["msg"] for error in excpt.errors()}
+            logger.error("Validation error: %s", errors)
+            raise excpt
 
         # Get index list for search query
         try:
@@ -390,11 +394,7 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
             groups=groups,
             tags=params.tags,
             path=params.path,
-            search_type=params.search_type
-            if params.search_type
-            else SearchTypeEnum.HYBRID
-            if check_hybrid_search_enabled()
-            else SearchTypeEnum.FULL_TEXT,
+            search_type=params.search_type,
         )["hits"]["hits"]
         logger.info("found %d results", len(result))
         logger.debug("results %s", result)


### PR DESCRIPTION
## Purpose

i used incoherent values between Find and Docs in SearchTypeEnum.

## Proposal

Description...

- [x] 🐛 fix `SearchTypeEnum` value
- [x] ♻️ move `search_type` default logic into the schemas to simplify the view
- [x] 🔊 add logs
- [x] ♻️ remove redundant `ResourceServerAuthentication`. this authentication_classes is already in `ResourceServerMixin`
- [x] 🐛 fix model name when embedding fails
