### PR TITLE
Fix to allow gitlab as OIDC provider

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "redis==5.3.1",
     "django-redis==6.0.0",
     "django==5.2.12",
-    "django-lasuite[all]==0.0.22",
+    "django-lasuite[all]==0.0.26",
     "djangorestframework==3.16.1",
     "drf_spectacular==0.29.0",
     "dockerflow==2024.4.2",


### PR DESCRIPTION
## Purpose

Will allow to use gitlab as OIDC for find. There was an issue with the OIDC controller.
- https://github.com/suitenumerique/django-lasuite/issues/67

## Proposal

- [x] Simply bump `django-lasuite`

\cc @qbey 