### PR TITLE
Allow UPPER_CASE names in pylintrc for Django settings convention

### DIFF
--- a/src/backend/.pylintrc
+++ b/src/backend/.pylintrc
@@ -278,8 +278,8 @@ argument-naming-style=snake_case
 attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
-# style
-#attr-rgx=
+# style. Allows snake_case and UPPER_CASE (Django settings convention).
+attr-rgx=([a-z_][a-z0-9_]{2,30}|[A-Z][A-Z0-9_]+)$
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,
@@ -344,7 +344,7 @@ method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style
-method-rgx=([a-z_][a-z0-9_]{2,50}|setUp|set[Uu]pClass|tearDown|tear[Dd]ownClass|assert[A-Z]\w*|maxDiff|test_[a-z0-9_]+)$
+method-rgx=([a-z_][a-z0-9_]{2,50}|[A-Z][A-Z0-9_]+|setUp|set[Uu]pClass|tearDown|tear[Dd]ownClass|assert[A-Z]\w*|maxDiff|test_[a-z0-9_]+)$
 
 # Naming style matching correct module names
 module-naming-style=snake_case

--- a/src/backend/find/settings.py
+++ b/src/backend/find/settings.py
@@ -500,13 +500,11 @@ class Base(Configuration):
         },
     }
 
-    # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):
         """Environment in which the application is launched."""
         return self.__class__.__name__.lower()
 
-    # pylint: disable=invalid-name
     @property
     def RELEASE(self):
         """
@@ -577,7 +575,6 @@ class Development(Base):
     USE_SWAGGER = True
 
     def __init__(self):
-        # pylint: disable=invalid-name
         self.INSTALLED_APPS += ["django_extensions", "drf_spectacular_sidecar"]
 
 
@@ -592,7 +589,6 @@ class Test(Base):
     CELERY_TASK_ALWAYS_EAGER = values.BooleanValue(True)
 
     def __init__(self):
-        # pylint: disable=invalid-name
         self.INSTALLED_APPS += ["drf_spectacular_sidecar"]
 
 


### PR DESCRIPTION
## Summary

- Update `.pylintrc` to accept UPPER_CASE method/property and attribute names, matching Django settings conventions (`ENVIRONMENT`, `RELEASE`, `INSTALLED_APPS`)
- Remove 4 inline `# pylint: disable=invalid-name` comments from `settings.py` that are no longer needed
- Pylint score: 10.00/10 after changes