### PR TITLE
fix(renovate): disable dependency grouping to unblock individual updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "labels": ["dependencies", "noChangeLog"],
   "packageRules": [
     {
-      "matchManagers": ["pep621"],
+      "matchPackagePatterns": ["*"],
       "groupName": null
     }
   ]


### PR DESCRIPTION
## Summary

- Replace the pep621-only `groupName: null` rule with a catch-all that applies to **all** dependency types
- Each package now gets its own PR instead of being grouped per manager

## Why

The base config at `numerique-gouv/renovate-configuration` groups all dependencies by manager (e.g. "GitHub Actions dependencies", "python dependencies"). This means if **one** package in the group hasn't met the 7-day `minimumReleaseAge`, the entire group is blocked — see PR #75 where the `renovate/stability-days` check keeps all 10 GitHub Actions updates stuck because of a single too-new release.

With this change, each dependency update is independent, so packages that have met the release age can be merged without waiting for others.