### PR TITLE
WIP: unblock Renovate by pinning CI action dependencies

### DIFF
--- a/.github/workflows/find.yml
+++ b/.github/workflows/find.yml
@@ -63,13 +63,13 @@ jobs:
         working-directory: src/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: "src/backend/pyproject.toml"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install the project
         run: uv sync --locked --all-extras
 


### PR DESCRIPTION
## Summary
- Pin `lint-back` job action dependencies to SHA digests (matching #75)

## Changes
- `actions/checkout` → pinned to `de0fac2…` (v6)
- `actions/setup-python` → pinned to `a309ff8…` (v6)
- `astral-sh/setup-uv` → pinned to `0880764…` (v8.1.0)