### PR TITLE
📝(changelog) simplify changelog for initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,40 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+## Unreleased
 
 ## Added
 
-- 👷(docker) add arm64 platform support for image builds
-- ✨(backend) add semantic search
-- ✨(backend) add multi-embedding and chunking
-- ✨(backend) add analyzers to full-text search
-- ✨(backend) handle french, english, german and dutch 
-- ✨(backend) add evaluation command
-- backend application
-- helm chart
-- ✨(backend) allow indexation of documents with either empty content or title.
-- ✨(api) new fulltext 'search/' view with OIDC resource server authentication
-- ✨(backend) limit access to documents : public & authenticated with a
-              list of services
-- 🔧(compose) rename docker network 'lasuite-net' as 'lasuite-network'
-- ✨(backend) add demo service for Drive.
-- ✨(backend) add OPENSEARCH_INDEX_PREFIX setting to prevent naming overlaping
-              issues if the opensearch database is shared between apps.
-- ✨(backend) add tags
-- ✨(backend) adapt to conversation RAG
-- ✨(backend) add deletion endpoint
-- ✨(backend) add path filter
-- ✨(backend) add search_type param
-
-## Changed
-
-- 🏗️(backend) switch Python dependency management to uv
-- ✨(backend) allow deletion by tags
-- ♻️(backend) improve the evaluation command
-
-## Fixed
-
-- 🐛(backend) fix missing index creation in 'index/' view
-- 🐛(backend) fix parallel test execution issues
-- 🐛(backend) fix search type value #68
+- 🎉(project) Initial release


### PR DESCRIPTION
## Summary

- Simplify changelog to single "Initial release" entry since no releases have been made yet