### PR TITLE
⬆️(dependencies) update redis to v6.4.0

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -28,23 +28,23 @@ dependencies = [
     "celery[redis]==5.6.3",
     "django-configurations==2.5.1",
     "django-cors-headers==4.9.0",
-    "redis==5.3.1",
+    "django-lasuite[all]==0.0.26",
     "django-redis==6.0.0",
     "django==6.0.4",
-    "django-lasuite[all]==0.0.26",
     "djangorestframework==3.17.1",
-    "drf_spectacular==0.29.0",
     "dockerflow==2026.3.4",
+    "drf_spectacular==0.29.0",
     "gunicorn==25.3.0",
-    "py3langid==0.3.0",
     "langchain-text-splitters==1.1.2",
     "mozilla-django-oidc==5.0.2",
+    "opensearch-py==3.1.0",
     "psycopg[binary]==3.3.3",
+    "py3langid==0.3.0",
     "pydantic==2.12.5",
     "pyjwt==2.12.1",
+    "redis==6.4.0",
     "requests==2.33.1",
     "sentry-sdk==2.58.0",
-    "opensearch-py==3.1.0",
     "whitenoise==6.12.0",
 ]
 
@@ -56,23 +56,23 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "django-extensions==4.1",
-    "factory_boy==3.3.3",
-    "drf-spectacular-sidecar==2026.4.14",
-    "faker==40.15.0",
-    "ipdb==0.13.13",
-    "ipython==9.13.0",
-    "pyfakefs==6.2.0",
-    "pylint-django==2.7.0",
-    "pylint==4.0.5",
-    "pytest-cov==7.1.0",
-    "pytest-django==4.12.0",
-    "pytest==9.0.3",
-    "pytest-icdiff==0.9",
-    "pytest-xdist==3.8.0",
-    "responses==0.26.0",
-    "ruff==0.15.12",
-    "types-requests==2.33.0.20260408",
+  "django-extensions==4.1",
+  "drf-spectacular-sidecar==2026.4.14",
+  "factory_boy==3.3.3",
+  "faker==40.15.0",
+  "ipdb==0.13.13",
+  "ipython==9.13.0",
+  "pyfakefs==6.2.0",
+  "pylint-django==2.7.0",
+  "pylint==4.0.5",
+  "pytest-cov==7.1.0",
+  "pytest-django==4.12.0",
+  "pytest-icdiff==0.9",
+  "pytest-xdist==3.8.0",
+  "pytest==9.0.3",
+  "responses==0.26.0",
+  "ruff==0.15.12",
+  "types-requests==2.33.0.20260408",
 ]
 
 [tool.setuptools]
@@ -84,52 +84,57 @@ universal = true
 
 [tool.ruff]
 exclude = [
-    ".git",
-    ".venv",
-    "build",
-    "venv",
-    "__pycache__",
-    "*/migrations/*",
-    ".vscode*"
+  ".git",
+  ".venv",
+  "build",
+  "venv",
+  "__pycache__",
+  "*/migrations/*",
+  ".vscode*",
 ]
 line-length = 88
 
 
 [tool.ruff.lint]
 select = [
-    "B", # flake8-bugbear
-    "BLE", # flake8-blind-except
-    "C4", # flake8-comprehensions
-    "DJ", # flake8-django
-    "I", # isort
-    "PLC", # pylint-convention
-    "PLE", # pylint-error
-    "PLR", # pylint-refactoring
-    "PLW", # pylint-warning
-    "RUF100", # Ruff unused-noqa
-    "RUF200", # Ruff check pyproject.toml
-    "S", # flake8-bandit
-    "SLF", # flake8-self
-    "T20", # flake8-print
+  "B",      # flake8-bugbear
+  "BLE",    # flake8-blind-except
+  "C4",     # flake8-comprehensions
+  "DJ",     # flake8-django
+  "I",      # isort
+  "PLC",    # pylint-convention
+  "PLE",    # pylint-error
+  "PLR",    # pylint-refactoring
+  "PLW",    # pylint-warning
+  "RUF100", # Ruff unused-noqa
+  "RUF200", # Ruff check pyproject.toml
+  "S",      # flake8-bandit
+  "SLF",    # flake8-self
+  "T20",    # flake8-print
 ]
-ignore= ["DJ001", "PLR2004"]
+ignore = ["DJ001", "PLR2004"]
 
 [tool.ruff.lint.isort]
-section-order = ["future","standard-library","django","third-party","find","first-party","local-folder"]
-sections = { find=["core"], django=["django"] }
+section-order = [
+  "future",
+  "standard-library",
+  "django",
+  "third-party",
+  "find",
+  "first-party",
+  "local-folder",
+]
+sections = { find = ["core"], django = ["django"] }
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["S", "SLF"]
 
 [tool.pytest.ini_options]
 addopts = [
-    "-v",
-    "--cov-report",
-    "term-missing",
-    # Allow test files to have the same name in different directories.
-    "--import-mode=importlib",
+  "-v",
+  "--cov-report",
+  "term-missing",
+  # Allow test files to have the same name in different directories.
+  "--import-mode=importlib",
 ]
-python_files = [
-    "test_*.py",
-    "tests.py",
-]
+python_files = ["test_*.py", "tests.py"]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -572,7 +572,7 @@ requires-dist = [
     { name = "pytest-django", marker = "extra == 'dev'", specifier = "==4.12.0" },
     { name = "pytest-icdiff", marker = "extra == 'dev'", specifier = "==0.9" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
-    { name = "redis", specifier = "==5.3.1" },
+    { name = "redis", specifier = "==6.4.0" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "responses", marker = "extra == 'dev'", specifier = "==0.26.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
@@ -1395,14 +1395,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "5.3.1"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Updates `redis` from `5.3.1` to `6.4.0` (max compatible version with `kombu<6.5`)
- Fixes dependency conflict that blocked PR #78 (which tried to upgrade to `redis==7.4.0`)

The `kombu` library (used by Celery) currently requires `redis<6.5`, so `7.x` is not yet supported upstream.