### PR TITLE
👷(dev) add pre-commit hooks for code quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,65 @@
+# Pre-commit hooks configuration
+# Install: pre-commit install --install-hooks -t pre-commit -t commit-msg
+# Run manually: pre-commit run --all-files
+
+default_language_version:
+  python: python3.12
+
+repos:
+  # General pre-commit hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]
+        exclude: ^src/helm/  # Helm templates use Go templating syntax
+      - id: check-toml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
+  # Ruff - Python linter and formatter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+        types_or: [python, pyi]
+      - id: ruff-format
+        types_or: [python, pyi]
+
+  # Pylint
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: bash -c 'cd src/backend && uv run pylint "${@#src/backend/}"' --
+        language: system
+        types: [python]
+        files: ^src/backend/
+        exclude: /migrations/
+
+  # Gitlint - Commit message linting
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+        stages: [commit-msg]
+
+  # Require signed-off commits (-s flag)
+  - repo: local
+    hooks:
+      - id: check-signoff
+        name: check sign-off
+        entry: grep -q "^Signed-off-by:"
+        language: system
+        stages: [commit-msg]

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,10 @@ lint-pylint: ## lint back-end python sources with pylint only on changed files f
 	bin/pylint .
 .PHONY: lint-pylint
 
+pre-commit-install: ## install pre-commit hooks
+	@pre-commit install --install-hooks -t pre-commit -t commit-msg
+.PHONY: pre-commit-install
+
 test: ## run project tests
 	@$(MAKE) test-back-parallel
 .PHONY: test
@@ -261,4 +265,3 @@ build-k8s-cluster: ## build the kubernetes cluster using kind
 start-tilt: ## start the kubernetes cluster using kind
 	tilt up -f ./bin/Tiltfile
 .PHONY: build-k8s-cluster
-

--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ $ docker compose version
 > avoided by assigning your user to the `docker` group. See docker 
 > [Documentation](https://docs.docker.com/engine/install/linux-postinstall/)
 
+#### Optional: pre-commit
+
+For local code quality checks before committing, you can install
+[pre-commit](https://pre-commit.com/) system-wide:
+
+```bash
+$ pip install pre-commit
+# or
+$ pipx install pre-commit
+```
+
+Then enable the hooks with:
+
+```bash
+$ make pre-commit-install
+```
+
 ### Project bootstrap
 
 The easiest way to start working on the project is to use GNU Make:


### PR DESCRIPTION
## Summary
- Add pre-commit configuration with hooks for code quality enforcement
- Add `make pre-commit-install` target for easy setup

### Hooks included:
- **Formatting**: ruff format, trailing whitespace, EOF fixer, mixed line endings
- **Linting**: ruff check, pylint
- **Commit quality**: gitlint (gitmoji+scope format), sign-off check
- **Security**: detect private keys, block large files
- **Validation**: YAML, TOML, JSON syntax checks
- **Branch protection**: block direct commits to main

### Setup
```bash
make pre-commit-install
```