### PR TITLE
🔥(docker) remove unused dockerize service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -95,9 +95,6 @@ services:
     depends_on:
       - app
 
-  dockerize:
-    image: jwilder/dockerize
-
   crowdin:
     image: crowdin/cli:3.16.0
     volumes:


### PR DESCRIPTION
## Summary
- Remove unused `dockerize` service from compose.yml (no other service references it)

noChangelog