### PR TITLE
🔥(backend) remove dead code identified by vulture

### DIFF
--- a/src/backend/core/services/indexing.py
+++ b/src/backend/core/services/indexing.py
@@ -66,11 +66,6 @@ def prepare_document_for_indexing(document):
     }
 
 
-def format_document(title, content):
-    """Format document for language detection"""
-    return f"<{title}>:<{content}>"
-
-
 def detect_language_code(text):
     """Detect the language code of the document content."""
 

--- a/src/backend/core/services/search.py
+++ b/src/backend/core/services/search.py
@@ -50,7 +50,6 @@ def search(  # noqa : PLR0913
             "size": nb_results,
             "query": query,
         },
-        params=get_params(),
         # disable=unexpected-keyword-arg because
         # ignore_unavailable is not in the method declaration
         ignore_unavailable=True,
@@ -173,8 +172,3 @@ def get_sort(order_by, order_direction):
         return {"_score": {"order": order_direction}}
 
     return {order_by: {"order": order_direction}}
-
-
-def get_params():
-    """Build OpenSearch search parameters"""
-    return {}

--- a/src/backend/core/tests/conftest.py
+++ b/src/backend/core/tests/conftest.py
@@ -2,30 +2,11 @@
 
 import pytest
 from faker import Faker
-from lasuite.oidc_resource_server.authentication import (
-    get_resource_server_backend,
-)
 from opensearchpy.exceptions import NotFoundError
 
 from core.services import opensearch
 
 fake = Faker()
-
-
-@pytest.fixture(name="jwt_rs_backend")
-def jwt_resource_server_backend_fixture(settings):
-    """Fixture to switch the backend to the JWTResourceServerBackend."""
-    _original_backend = str(settings.OIDC_RS_BACKEND_CLASS)
-
-    settings.OIDC_RS_BACKEND_CLASS = (
-        "lasuite.oidc_resource_server.backend.JWTResourceServerBackend"
-    )
-    get_resource_server_backend.cache_clear()
-
-    yield
-
-    settings.OIDC_RS_BACKEND_CLASS = _original_backend
-    get_resource_server_backend.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -5,32 +5,12 @@ from typing import List
 
 from django.conf import settings as django_settings
 
-from opensearchpy.exceptions import NotFoundError
 from opensearchpy.helpers import bulk
 
-from core import factories
 from core.services.indexing import ensure_index_exists, prepare_document_for_indexing
 from core.services.opensearch import opensearch_client
 
 logger = logging.getLogger(__name__)
-
-
-def bulk_create_documents(document_payloads):
-    """Create documents in bulk from payloads"""
-    return [
-        factories.DocumentSchemaFactory.build(**document_payload, users=["user_sub"])
-        for document_payload in document_payloads
-    ]
-
-
-def delete_index(index_name):
-    """Delete the search index if it exists"""
-    logger.info("Deleting Index %s", index_name)
-
-    try:
-        opensearch_client().indices.delete(index=index_name)
-    except NotFoundError:
-        logger.info("Search pipeline %s not found, nothing to delete.", index_name)
 
 
 def prepare_index(index_name, documents: List):


### PR DESCRIPTION
## Summary

- Remove 5 unused functions/fixtures identified by vulture dead code scanner
- Clean up 3 now-unused imports

## Removed Dead Code

| File | Item | Reason |
|------|------|--------|
| `core/services/indexing.py` | `format_document()` | Leftover from hybrid search removal |
| `core/services/search.py` | `get_params()` | Returned empty dict, never used |
| `core/utils.py` | `bulk_create_documents()` | Never integrated |
| `core/utils.py` | `delete_index()` | Unused test utility |
| `core/tests/conftest.py` | `jwt_rs_backend` fixture | Never used by any test |

## Cleaned Up Imports

- `NotFoundError` from `core/utils.py`
- `factories` from `core/utils.py`  
- `get_resource_server_backend` from `core/tests/conftest.py`