### PR TITLE
📝(docs) rewrite documentation for unified index architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,144 @@
 # Find
 
-Find can index documents from several applications sharing a common OIDC federation
-and allows users to search documents with their access rights accross all applications
-in the federation.
+**Federated document search for OIDC-connected applications.**
 
-Find is built on top of [Django Rest
-Framework](https://www.django-rest-framework.org/).
+Find provides a unified search API that enables applications in an OIDC federation to index and search documents with proper access control. It abstracts the underlying search engine, allowing you to choose the backend that best fits your needs.
 
-## Getting started
+## Key Features
 
-### Prerequisite
+- **Unified Index**: All documents stored in a single index, isolated by service
+- **Access Control**: Fine-grained permissions via users, groups, and reach levels
+- **Search Abstraction**: Swap search backends without changing application code
+- **OIDC Integration**: Seamless authentication with your identity provider
 
-Make sure you have a recent version of Docker and [Docker
-Compose](https://docs.docker.com/compose/install) installed on your laptop:
+## How It Works
 
-```bash
-$ docker -v
-  Docker version 27.4.1, build b9d17ea
-
-$ docker compose version
-  Docker Compose version v2.32.1
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Applications                              │
+│              (Docs, Drive, Messaging)                        │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+┌──────────────────────────▼──────────────────────────────────┐
+│                         Find                                 │
+│         • Index documents with access control                │
+│         • Search with automatic permission filtering         │
+│         • Backend-agnostic API                              │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+         ┌─────────────────┼─────────────────┐
+         ▼                 ▼                 ▼
+    ┌─────────┐      ┌──────────┐      ┌───────────┐
+    │OpenSearch│      │TypeSense │      │Meilisearch│
+    └─────────┘      └──────────┘      └───────────┘
 ```
 
-> ⚠️ You may need to run the following commands with `sudo` but this can be
-> avoided by assigning your user to the `docker` group. See docker 
-> [Documentation](https://docs.docker.com/engine/install/linux-postinstall/)
-
-#### Optional: pre-commit
-
-For local code quality checks before committing, you can install
-[pre-commit](https://pre-commit.com/) system-wide:
+## Quick Start
 
 ```bash
-$ pip install pre-commit
-# or
-$ pipx install pre-commit
+# Clone and setup
+git clone https://github.com/suitenumerique/find.git
+cd find
+cp env.d/development/common.dist.env env.d/development/common.env
+
+# Start services
+make bootstrap
+make migrate
+make create-index
+
+# Find is running at http://localhost:8081
 ```
 
-Then enable the hooks with:
+## API Overview
+
+### Index a Document
 
 ```bash
-$ make pre-commit-install
+curl -X POST http://localhost:8081/api/v1.0/documents/index/ \
+  -H "Authorization: Token YOUR_SERVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "doc-123",
+    "title": "Project Roadmap",
+    "content": "Q1 objectives and milestones...",
+    "users": ["user-sub-1"],
+    "groups": ["engineering"],
+    "reach": "restricted"
+  }'
 ```
 
-### Project bootstrap
-
-The easiest way to start working on the project is to use GNU Make:
+### Search Documents
 
 ```bash
-$ make bootstrap
+curl -X POST http://localhost:8081/api/v1.0/documents/search/ \
+  -H "Authorization: Bearer OIDC_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "roadmap"
+  }'
 ```
 
-This command builds the `app` container, installs dependencies, performs
-database migrations and compile translations. It's a good idea to use this
-command each time you are pulling code from the project repository to avoid
-dependency-related or migration-related issues.
+## Supported Search Backends
 
-Your Docker services should now be up and running 🎉
+| Backend | Best For |
+|---------|----------|
+| **OpenSearch** | Large-scale deployments, complex queries |
+| **TypeSense** | Low-latency, typo-tolerant search |
+| **Meilisearch** | Quick setup, excellent relevance |
 
-### Adding content
-
-You can create a basic demo site by running:
-
-    $ make demo
-
-Finally, you can check all available Make rules using:
+Configure via environment variable:
 
 ```bash
-$ make help
+SEARCH_BACKEND=opensearch  # or typesense, meilisearch
 ```
 
-### Django admin
+## Access Control
 
-You can access the Django admin site at
-[http://localhost:8071/admin](http://localhost:8071/admin).
+Documents are protected by claims set during indexation:
 
-You first need to create a superuser account:
+| Field | Description |
+|-------|-------------|
+| `users` | List of user SUBs who can access |
+| `groups` | List of group slugs who can access |
+| `reach` | `public`, `authenticated`, or `restricted` |
+
+Find automatically filters search results based on the authenticated user's identity and group memberships.
+
+## Documentation
+
+- [Core Concepts](docs/concepts.md) - Unified index, claims, search abstraction
+- [Architecture](docs/architecture.md) - System design and data flow
+- [Setup Guide](docs/setup-indexer.md) - Installation and configuration
+- [Environment Variables](docs/env.md) - Complete configuration reference
+- [Docs Integration](docs/setup-for-docs.md) - Integrate with Docs
+- [Drive Integration](docs/setup-for-drive.md) - Integrate with Drive
+
+## Tech Stack
+
+- **Backend**: Django 6.0, Django REST Framework
+- **Search**: OpenSearch / TypeSense / Meilisearch
+- **Database**: PostgreSQL
+- **Queue**: Celery + Redis
+- **Auth**: OIDC (Mozilla Django OIDC)
+
+## Development
 
 ```bash
-$ make superuser
+# Run tests
+make test
+
+# Code quality
+make lint
+make format
+
+# Build Docker image
+make build
 ```
-
-## Contributing
-
-This project is intended to be community-driven, so please, do not hesitate to
-get in touch if you have any question related to our implementation or design
-decisions.
 
 ## License
 
-This work is released under the MIT License (see [LICENSE](./LICENSE)).
+MIT License - see [LICENSE](LICENSE) for details.
+
+## Contributing
+
+Contributions welcome! Please read our contributing guidelines before submitting PRs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,236 @@
-## Architecture
+# Architecture
 
-### Global system architecture
+## Overview
+
+Find is a federated document search service that provides a unified search API across multiple applications. It abstracts the underlying search engine, allowing applications to index and search documents without coupling to a specific backend.
+
+## System Architecture
 
 ```mermaid
 flowchart TD
-    Docs -- REST API --> Back("Backend (Django)")
-    Back --> DB("Database (PostgreSQL)")
-    Back -- REST API --> Opensearch
-    Back <--> Celery --> DB
-    User -- HTTP --> Dashboard --> Opensearch
-    Back -- REST API --> Embedding Endpoint
+    subgraph Applications["Applications (OIDC Federation)"]
+        Docs["Docs"]
+        Drive["Drive"]
+        Other["Other Services"]
+    end
+
+    subgraph Find["Find Service"]
+        API["REST API<br/>(Django + DRF)"]
+        Auth["Authentication<br/>• Service Tokens (indexing)<br/>• OIDC Bearer (search)"]
+        Claims["Claims Engine<br/>• Service ownership<br/>• User access control"]
+        Abstraction["Search Abstraction Layer"]
+    end
+
+    subgraph Backends["Search Backends (one active)"]
+        OS["OpenSearch"]
+        TS["TypeSense"]
+        MS["Meilisearch"]
+    end
+
+    subgraph Storage["Data Storage"]
+        DB["PostgreSQL<br/>(Services, Config)"]
+        Index["Unified Index<br/>(All Documents)"]
+    end
+
+    subgraph Workers["Background Workers"]
+        Celery["Celery"]
+        Redis["Redis"]
+    end
+
+    Docs --> |"Index API<br/>(Service Token)"| API
+    Drive --> |"Index API<br/>(Service Token)"| API
+    Other --> |"Index API<br/>(Service Token)"| API
+    
+    Docs --> |"Search API<br/>(OIDC Token)"| API
+    Drive --> |"Search API<br/>(OIDC Token)"| API
+    Other --> |"Search API<br/>(OIDC Token)"| API
+
+    API --> Auth
+    Auth --> Claims
+    Claims --> Abstraction
+    
+    Abstraction --> OS
+    Abstraction --> TS
+    Abstraction --> MS
+    
+    OS --> Index
+    TS --> Index
+    MS --> Index
+    
+    API --> DB
+    Celery --> Redis
+    API --> Celery
 ```
+
+## Data Flow
+
+### Indexing Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant API as Find API
+    participant Auth as Auth Layer
+    participant Claims as Claims Engine
+    participant Search as Search Backend
+    participant Index as Unified Index
+
+    App->>API: POST /api/v1.0/documents/index/<br/>Authorization: Token {service_token}
+    API->>Auth: Validate service token
+    Auth-->>API: Service identity (e.g., "docs")
+    API->>Claims: Verify write claims
+    Claims-->>API: Authorized for service "docs"
+    API->>Search: Index document with service="docs"
+    Search->>Index: Store in unified index
+    Index-->>Search: Indexed
+    Search-->>API: Success
+    API-->>App: 201 Created
+```
+
+### Search Flow
+
+```mermaid
+sequenceDiagram
+    participant User as User (via App)
+    participant App as Application
+    participant API as Find API
+    participant Auth as Auth Layer
+    participant Claims as Claims Engine
+    participant Search as Search Backend
+
+    User->>App: Search query
+    App->>API: POST /api/v1.0/documents/search/<br/>Authorization: Bearer {oidc_token}
+    API->>Auth: Validate OIDC token
+    Auth-->>API: User identity (sub, groups)
+    API->>Claims: Build access filter
+    Note over Claims: Filter by:<br/>• service (app's service only)<br/>• user.sub in users<br/>• user.groups ∩ groups<br/>• reach level
+    Claims-->>API: Access control query
+    API->>Search: Execute search with filters
+    Search-->>API: Filtered results
+    API-->>App: Search results
+    App-->>User: Display results
+```
+
+## Components
+
+### REST API (Django + DRF)
+
+The API layer handles:
+
+- **Document Indexing**: Single and bulk document indexing
+- **Document Search**: Full-text search with filters
+- **Document Deletion**: Remove documents by ID or tags
+- **Health Checks**: Service availability endpoints
+
+### Authentication Layer
+
+Two authentication modes:
+
+| Mode | Used For | Token Type |
+|------|----------|------------|
+| **Service Token** | Indexing, Deletion | Static 50-char token |
+| **OIDC Bearer** | Search | JWT from OIDC provider |
+
+### Claims Engine
+
+Enforces access control:
+
+- **Service Claims**: Services can only access their own documents
+- **User Claims**: Users see documents based on `users`, `groups`, and `reach` fields
+- **Query Filtering**: Automatically applies access control to all queries
+
+### Search Abstraction Layer
+
+Backend-agnostic interface supporting:
+
+| Operation | Description |
+|-----------|-------------|
+| `index()` | Add or update documents |
+| `search()` | Full-text search with filters |
+| `delete()` | Remove documents |
+| `health()` | Backend health check |
+
+### Unified Index
+
+Single index containing all documents:
+
+- **Service isolation**: Documents tagged with source `service`
+- **Language support**: French, English, German, Dutch with appropriate analyzers
+- **Trigram matching**: Typo-tolerant search via n-gram tokenization
+
+## Deployment Architecture
+
+### Development
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Docker Compose                            │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           │
+│  │  App    │ │ Celery  │ │ Postgres│ │  Redis  │           │
+│  │ :8081   │ │ Worker  │ │ :25432  │ │ :6379   │           │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘           │
+│  ┌───────────────────┐ ┌─────────────────────────┐         │
+│  │ Search Backend    │ │ Dashboard (optional)    │         │
+│  │ :9200             │ │ :5601                   │         │
+│  └───────────────────┘ └─────────────────────────┘         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Production (Kubernetes)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Kubernetes Cluster                        │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  Deployment: find-backend (3 replicas)               │   │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐               │   │
+│  │  │ Pod 1   │ │ Pod 2   │ │ Pod 3   │               │   │
+│  │  └─────────┘ └─────────┘ └─────────┘               │   │
+│  └─────────────────────────────────────────────────────┘   │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  Deployment: find-celery (2 replicas)                │   │
+│  └─────────────────────────────────────────────────────┘   │
+│  ┌───────────────┐ ┌───────────────┐ ┌───────────────┐    │
+│  │  PostgreSQL   │ │    Redis      │ │Search Backend │    │
+│  │  (managed)    │ │  (managed)    │ │  (managed)    │    │
+│  └───────────────┘ └───────────────┘ └───────────────┘    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Search Backend Selection
+
+Find supports multiple search backends. Choose based on your requirements:
+
+| Backend | Strengths | Best For |
+|---------|-----------|----------|
+| **OpenSearch** | Scalability, complex queries, ES compatibility | Large deployments, existing ES expertise |
+| **TypeSense** | Speed, typo tolerance, simplicity | Real-time search, smaller datasets |
+| **Meilisearch** | Developer experience, fast setup, relevance | Quick deployment, excellent UX |
+
+Backend selection is configured via `SEARCH_BACKEND` environment variable. See [Environment Variables](env.md).
+
+## Security Considerations
+
+### Network Security
+
+- All service-to-service communication over internal network
+- Public endpoints behind reverse proxy with TLS
+- OIDC provider endpoints accessible for token validation
+
+### Authentication Security
+
+- Service tokens: 50-character cryptographically random strings
+- OIDC tokens: RS256/ES256 signed JWTs with audience validation
+- No user credentials stored in Find
+
+### Data Security
+
+- Documents filtered at query time (not presentation time)
+- Service isolation prevents cross-service data access
+- Audit logging for index/delete operations
+
+## Related Documentation
+
+- [Core Concepts](concepts.md) - Unified index, claims, abstraction explained
+- [Setup Guide](setup-indexer.md) - Configuration and deployment
+- [Environment Variables](env.md) - Complete configuration reference

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,215 @@
+# Find Core Concepts
+
+This document explains the fundamental concepts behind Find's architecture.
+
+## Overview
+
+Find is a **federated document search system** that provides a unified search API across multiple applications in an OIDC federation. It acts as an abstraction layer between applications and the underlying search engine, allowing users to search documents with proper access control.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Applications                              │
+│         (Docs, Drive, Messaging, etc.)                       │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ Index & Search API
+┌──────────────────────────▼──────────────────────────────────┐
+│                         Find                                 │
+│    ┌─────────────────────────────────────────────────────┐  │
+│    │              Search Abstraction Layer               │  │
+│    │         (Backend-agnostic interface)                │  │
+│    └─────────────────────────────────────────────────────┘  │
+│                           │                                  │
+│         ┌─────────────────┼─────────────────┐               │
+│         ▼                 ▼                 ▼               │
+│    ┌─────────┐      ┌──────────┐      ┌───────────┐        │
+│    │OpenSearch│      │TypeSense │      │Meilisearch│        │
+│    └─────────┘      └──────────┘      └───────────┘        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Unified Index
+
+All documents from all services are stored in a **single unified index**. Each document contains a `service` field that identifies which application indexed it.
+
+### Why Unified Index?
+
+- **Simplified operations**: One index to manage, backup, and scale
+- **Cross-service potential**: Foundation for future cross-application search
+- **Consistent schema**: All documents share the same field mappings
+- **Easier migrations**: Switch search backends without per-service complexity
+
+### Document Structure
+
+Every document in the unified index contains:
+
+```json
+{
+  "id": "uuid",
+  "service": "docs",           // Which service owns this document
+  "title": "Document title",
+  "content": "Full text content",
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z",
+  "size": 1024,
+  
+  // Access control (set by the indexing service)
+  "users": ["user-sub-1", "user-sub-2"],
+  "groups": ["group-slug-1"],
+  "reach": "restricted",
+  
+  // Metadata
+  "tags": ["tag1", "tag2"],
+  "path": "/folder/subfolder",
+  "depth": 2,
+  "numchild": 0,
+  "is_active": true
+}
+```
+
+## Service Claims
+
+A **service** is an application registered with Find (e.g., Docs, Drive). Each service has **claims** over documents it indexes.
+
+### Service Write Claims
+
+Services authenticate using a secure token and can:
+
+- **Index** documents with their service identifier
+- **Update** documents they previously indexed
+- **Delete** documents they own
+
+A service **cannot** modify documents indexed by another service.
+
+### Service Read Claims
+
+By default, a service can only search documents it has indexed. This ensures:
+
+- **Data isolation**: Each application's documents remain separate
+- **Clear ownership**: No confusion about document provenance
+- **Security by default**: No accidental data leakage between services
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│    Docs     │     │    Drive    │     │  Messaging  │
+│   Service   │     │   Service   │     │   Service   │
+└──────┬──────┘     └──────┬──────┘     └──────┬──────┘
+       │                   │                   │
+       │ Index/Search      │ Index/Search      │ Index/Search
+       │ own docs only     │ own docs only     │ own docs only
+       │                   │                   │
+       ▼                   ▼                   ▼
+┌─────────────────────────────────────────────────────────┐
+│                    Unified Index                         │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────────┐   │
+│  │service:docs │ │service:drive│ │service:messaging│   │
+│  │ documents   │ │ documents   │ │   documents     │   │
+│  └─────────────┘ └─────────────┘ └─────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## User Read Claims
+
+Users don't interact with Find directly - they use their application (Docs, Drive, etc.). When a user searches, Find determines what they can see based on **read claims** set during document indexation.
+
+### How Read Claims Work
+
+When a service indexes a document, it specifies who can read it:
+
+| Field | Purpose |
+|-------|---------|
+| `users` | List of user SUBs (OIDC subject identifiers) who can access |
+| `groups` | List of group slugs who can access |
+| `reach` | Visibility level: `public`, `authenticated`, or `restricted` |
+
+### Reach Levels
+
+| Reach | Who Can See |
+|-------|------------|
+| `public` | Anyone (no authentication required) |
+| `authenticated` | Any authenticated user in the federation |
+| `restricted` | Only users listed in `users` or `groups` fields |
+
+### Search Access Control
+
+When a user searches, Find filters results based on:
+
+1. The user's OIDC `sub` (subject) claim
+2. The user's group memberships
+3. Document visibility (reach level)
+4. Documents the user has explicitly visited (for public/authenticated reach)
+
+```
+User Search Request
+       │
+       ▼
+┌─────────────────────────────────────┐
+│        Access Control Filter         │
+│                                      │
+│  Document is visible if:             │
+│                                      │
+│  (reach != restricted AND visited)   │
+│           OR                         │
+│  (user.sub IN document.users)        │
+│           OR                         │
+│  (user.groups ∩ document.groups)     │
+│                                      │
+└─────────────────────────────────────┘
+       │
+       ▼
+   Filtered Results
+```
+
+## Search Abstraction Layer
+
+Find provides a **backend-agnostic search API**. Applications interact with Find's REST API without knowing which search engine is used underneath.
+
+### Supported Backends
+
+Find supports multiple search backends:
+
+| Backend | Best For |
+|---------|----------|
+| **OpenSearch** | Large-scale deployments, complex queries, existing Elasticsearch expertise |
+| **TypeSense** | Low-latency searches, typo tolerance, simpler operations |
+| **Meilisearch** | Fast setup, excellent relevance, developer-friendly |
+
+### API Agnosticism
+
+The Find API is completely agnostic to the backend:
+
+- **Same endpoints** regardless of backend
+- **Same request/response format**
+- **Same query syntax**
+- **Same access control behavior**
+
+Applications don't need to change when you switch backends. This enables:
+
+- **Backend migrations** without application changes
+- **A/B testing** different search engines
+- **Environment flexibility** (e.g., Meilisearch for dev, OpenSearch for prod)
+
+### Configuration
+
+The backend is selected via environment variable:
+
+```bash
+SEARCH_BACKEND=opensearch  # or typesense, meilisearch
+```
+
+Each backend has its own configuration section. See [Environment Variables](env.md) for details.
+
+## Summary
+
+| Concept | Description |
+|---------|-------------|
+| **Unified Index** | Single index for all documents, identified by `service` field |
+| **Service Write Claims** | Services can only modify their own documents |
+| **Service Read Claims** | Services can only search their own documents |
+| **User Read Claims** | Access determined by `users`, `groups`, and `reach` fields |
+| **Search Abstraction** | Backend-agnostic API supporting multiple search engines |
+
+## Next Steps
+
+- [Architecture Overview](architecture.md) - System architecture and data flow
+- [Setting Up Find](setup-indexer.md) - Configuration and deployment
+- [Environment Variables](env.md) - Complete configuration reference

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,107 +1,238 @@
-# Find variables
+# Environment Variables
 
-Here we describe all environment variables that can be set for the find application.
+Complete reference for Find configuration.
 
-## find-backend container
+## Core Settings
 
-These are the environment variables you can set for the `find-backend` container.
+### Django Configuration
 
-| Option                                          | Description                                                                                                                 | default                                                                 |
-|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| API_USERS_LIST_LIMIT                            | Limit on API users                                                                                                          | 5                                                                       |
-| API_USERS_LIST_THROTTLE_RATE_BURST              | Throttle rate for api on burst                                                                                              | 30/minute                                                               |
-| API_USERS_LIST_THROTTLE_RATE_SUSTAINED          | Throttle rate for api                                                                                                       | 180/hour                                                                |
-| CACHES_DEFAULT_TIMEOUT                          | Cache default timeout                                                                                                       | 30                                                                      |
-| CACHES_KEY_PREFIX                               | The prefix used to every cache keys.                                                                                        | docs                                                                    |
-| DB_ENGINE                                       | Engine to use for database connections                                                                                      | django.db.backends.postgresql_psycopg2                                  |
-| DB_HOST                                         | Host of the database                                                                                                        | localhost                                                               |
-| DB_NAME                                         | Name of the database                                                                                                        | impress                                                                 |
-| DB_PASSWORD                                     | Password to authenticate with                                                                                               | pass                                                                    |
-| DB_PORT                                         | Port of the database                                                                                                        | 5432                                                                    |
-| DB_USER                                         | User to authenticate with                                                                                                   | dinum                                                                   |
-| DJANGO_ALLOWED_HOSTS                            | Allowed hosts                                                                                                               | []                                                                      |
-| DJANGO_CELERY_BROKER_TRANSPORT_OPTIONS          | Celery broker transport options                                                                                             | {}                                                                      |
-| DJANGO_CELERY_BROKER_URL                        | Celery broker url                                                                                                           | redis://redis:6379/0                                                    |
-| DJANGO_CORS_ALLOW_ALL_ORIGINS                   | Allow all CORS origins                                                                                                      | false                                                                   |
-| DJANGO_CORS_ALLOWED_ORIGIN_REGEXES              | List of origins allowed for CORS using regular expressions                                                                 | []                                                                      |
-| DJANGO_CORS_ALLOWED_ORIGINS                     | List of origins allowed for CORS                                                                                            | []                                                                      |
-| DJANGO_CSRF_TRUSTED_ORIGINS                     | CSRF trusted origins                                                                                                        | []                                                                      |
-| DJANGO_EMAIL_BACKEND                            | Email backend library                                                                                                       | django.core.mail.backends.smtp.EmailBackend                             |
-| DJANGO_EMAIL_BRAND_NAME                         | Brand name for email                                                                                                        |                                                                         |
-| DJANGO_EMAIL_FROM                               | Email address used as sender                                                                                                | from@example.com                                                        |
-| DJANGO_EMAIL_HOST                               | Hostname of email                                                                                                           |                                                                         |
-| DJANGO_EMAIL_HOST_PASSWORD                      | Password to authenticate with on the email host                                                                             |                                                                         |
-| DJANGO_EMAIL_HOST_USER                          | User to authenticate with on the email host                                                                                 |                                                                         |
-| DJANGO_EMAIL_LOGO_IMG                           | Logo for the email                                                                                                          |                                                                         |
-| DJANGO_EMAIL_PORT                               | Port used to connect to email host                                                                                          |                                                                         |
-| DJANGO_EMAIL_USE_SSL                            | Use ssl for email host connection                                                                                           | false                                                                   |
-| DJANGO_EMAIL_USE_TLS                            | Use tls for email host connection                                                                                           | false                                                                   |
-| DJANGO_SECRET_KEY                               | Secret key                                                                                                                  |                                                                         |
-| DJANGO_SERVER_TO_SERVER_API_TOKENS              |                                                                                                                             | []                                                                      |
-| DOCUMENT_IMAGE_MAX_SIZE                         | Maximum size of document in bytes                                                                                           | 10485760                                                                |
-| FRONTEND_CSS_URL                                | To add a external css file to the app                                                                                       |                                                                         |
-| FRONTEND_HOMEPAGE_FEATURE_ENABLED               | Frontend feature flag to display the homepage                                                                               | false                                                                   |
-| FRONTEND_THEME                                  | Frontend theme to use                                                                                                       |                                                                         |
-| LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD         | Language detection confidence threshold                                                                                     | 0.75                                                                    |
-| LOGGING_LEVEL_LOGGERS_APP                       | Application logging level. options are "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"                                         | INFO                                                                    |
-| LOGGING_LEVEL_LOGGERS_ROOT                      | Default logging level. options are "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"                                             | INFO                                                                    |
-| LOGIN_REDIRECT_URL                              | Login redirect url                                                                                                          |                                                                         |
-| LOGIN_REDIRECT_URL_FAILURE                      | Login redirect url on failure                                                                                               |                                                                         |
-| LOGOUT_REDIRECT_URL                             | Logout redirect url                                                                                                         |                                                                         |
-| MALWARE_DETECTION_BACKEND                       | The malware detection backend use from the django-lasuite package                                                           | lasuite.malware_detection.backends.dummy.DummyBackend                   |
-| MALWARE_DETECTION_PARAMETERS                    | A dict containing all the parameters to initiate the malware detection backend                                              | {"callback_path": "core.malware_detection.malware_detection_callback",} |
-| MEDIA_BASE_URL                                  |                                                                                                                             |                                                                         |
-| NO_WEBSOCKET_CACHE_TIMEOUT                      | Cache used to store current editor session key when only users without websocket are editing a document                     | 120                                                                     |
-| OIDC_ALLOW_DUPLICATE_EMAILS                     | Allow duplicate emails                                                                                                      | false                                                                   |
-| OIDC_AUTH_REQUEST_EXTRA_PARAMS                  | OIDC extra auth parameters                                                                                                  | {}                                                                      |
-| OIDC_CREATE_USER                                | Create used on OIDC                                                                                                         | false                                                                   |
-| OIDC_DRF_AUTH_BACKEND                           | DRF Authentication backend class for OIDC                                                                                   | lasuite.oidc_login.backends.OIDCAuthenticationBackend                   |
-| OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION       | Fallback to email for identification                                                                                        | true                                                                    |
-| OIDC_OP_AUTHORIZATION_ENDPOINT                  | Authorization endpoint for OIDC                                                                                             |                                                                         |
-| OIDC_OP_INTROSPECTION_ENDPOINT                  | Introspection endpoint for OIDC                                                                                             |                                                                         |
-| OIDC_OP_JWKS_ENDPOINT                           | JWKS endpoint for OIDC                                                                                                      |                                                                         |
-| OIDC_OP_LOGOUT_ENDPOINT                         | Logout endpoint for OIDC                                                                                                    |                                                                         |
-| OIDC_OP_TOKEN_ENDPOINT                          | Token endpoint for OIDC                                                                                                     |                                                                         |
-| OIDC_OP_USER_ENDPOINT                           | User endpoint for OIDC                                                                                                      |                                                                         |
-| OIDC_REDIRECT_ALLOWED_HOSTS                     | Allowed hosts for OIDC redirect url                                                                                         | []                                                                      |
-| OIDC_REDIRECT_REQUIRE_HTTPS                     | Require https for OIDC redirect url                                                                                         | false                                                                   |
-| OIDC_RP_CLIENT_ID                               | Client id used for OIDC                                                                                                     | impress                                                                 |
-| OIDC_RP_CLIENT_SECRET                           | Client secret used for OIDC                                                                                                 |                                                                         |
-| OIDC_RP_SCOPES                                  | Scopes requested for OIDC                                                                                                   | openid email                                                            |
-| OIDC_RP_SIGN_ALGO                               | verification algorithm used OIDC tokens                                                                                     | RS256                                                                   |
-| OIDC_RS_BACKEND_CLASS                           | Resource server backend class for OIDC                                                                                      | core.authentication.FinderResourceServerBackend                         |
-| OIDC_RS_AUDIENCE_CLAIM                          | The claim used to identify the audience                                                                                     | client_id                                                               |
-| OIDC_RS_CLIENT_ID                               | Client id used for OIDC resource server                                                                                     |                                                                         |
-| OIDC_RS_CLIENT_SECRET                           | Client secret used for OIDC resource server                                                                                 |                                                                         |
-| OIDC_RS_SIGNING_ALGO                            | Signing algorithm                                                                                                           | ES256                                                                   |
-| OIDC_RS_SCOPES                                  | Required scopes for authentication                                                                                          | ["openid"]                                                              |
-| OIDC_RS_PRIVATE_KEY_STR                         | Private key for encryption/decryption                                                                                       |                                                                         |
-| OIDC_RS_ENCRYPTION_KEY_TYPE                     | Encryption key type (RSA, EC, etc.)                                                                                         | RSA                                                                     |
-| OIDC_RS_ENCRYPTION_ALGO                         | Encryption algorithm                                                                                                        | RSA-OAEP                                                                |
-| OIDC_RS_ENCRYPTION_ENCODING                     | Encryption encoding algorithm                                                                                               | A256GCM                                                                 |
-| OIDC_STORE_ID_TOKEN                             | Store OIDC token                                                                                                            | true                                                                    |
-| OIDC_USE_NONCE                                  | Use nonce for OIDC                                                                                                          | true                                                                    |
-| OIDC_USERINFO_FULLNAME_FIELDS                   | OIDC token claims to create full name                                                                                       | ["first_name", "last_name"]                                             |
-| OIDC_USERINFO_SHORTNAME_FIELD                   | OIDC token claims to create shortname                                                                                       | first_name                                                              |
-| OIDC_VERIFY_SSL                                 | Enable SSL validation for OIDC                                                                                              | true                                                                    |
-| OIDC_TIMEOUT                                    | Timeout delay for OID requests                                                                                              |                                                                         |
-| OIDC_PROXY                                      | Defines a proxy for all requests to the OpenID Connect provider                                                             |                                                                         |
-| OPENSEARCH_HOST                                 | Opensearch database url                                                                                                     | default                                                                 |
-| OPENSEARCH_PORT                                 | Port of Opensearch database                                                                                                 | 9200                                                                    |
-| OPENSEARCH_USER                                 | Opensearch database user                                                                                                    | admin                                                                   |
-| OPENSEARCH_PASSWORD                             | Opensearch database user password                                                                                           |                                                                         |
-| OPENSEARCH_USE_SSL                              | Enable SSL connection for Opensearch database                                                                               | true                                                                    |
-| POSTHOG_KEY                                     | Posthog key for analytics                                                                                                   |                                                                         |
-| REDIS_URL                                       | Cache url                                                                                                                   | redis://redis:6379/1                                                    |
-| SENTRY_DSN                                      | Sentry host                                                                                                                 |                                                                         |
-| SESSION_COOKIE_AGE                              | duration of the cookie session                                                                                              | 60*60*12                                                                |
-| SPECTACULAR_SETTINGS_ENABLE_DJANGO_DEPLOY_CHECK |                                                                                                                             | false                                                                   |
-| STORAGES_STATICFILES_BACKEND                    |                                                                                                                             | whitenoise.storage.CompressedManifestStaticFilesStorage                 |
-| THEME_CUSTOMIZATION_CACHE_TIMEOUT               | Cache duration for the customization settings                                                                               | 86400                                                                   |
-| THEME_CUSTOMIZATION_FILE_PATH                   | Full path to the file customizing the theme. An example is provided in src/backend/impress/configuration/theme/default.json | BASE_DIR/impress/configuration/theme/default.json                       |
-| TRASHBIN_CUTOFF_DAYS                            | Trashbin cutoff                                                                                                             | 30                                                                      |
-| TRIGRAMS_BOOST                                  | weight boost applied to trigram score in document matching score                                                            | 0.25                                                                    |
-| TRIGRAMS_MINIMUM_SHOULD_MATCH                   | minimal number or proportion of trigrams having to match to score                                                           | 0.75%                                                                   |
-| USER_OIDC_ESSENTIAL_CLAIMS                      | Essential claims in OIDC token                                                                                              | []                                                                      |
-| Y_PROVIDER_API_BASE_URL                         | Y Provider url                                                                                                              |                                                                         |
-| Y_PROVIDER_API_KEY                              | Y provider API key                                                                                                          |                                                                         |
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `DJANGO_SECRET_KEY` | Cryptographic signing key | - | **Yes** |
+| `DJANGO_DEBUG` | Enable debug mode | `false` | No |
+| `DJANGO_ALLOWED_HOSTS` | Comma-separated allowed hostnames | `*` | Production |
+| `DJANGO_CSRF_TRUSTED_ORIGINS` | Comma-separated trusted origins for CSRF | - | Production |
+| `DJANGO_SETTINGS_MODULE` | Settings module path | `find.settings` | No |
+
+### Database (PostgreSQL)
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `POSTGRES_HOST` | Database hostname | `localhost` | **Yes** |
+| `POSTGRES_PORT` | Database port | `5432` | No |
+| `POSTGRES_DB` | Database name | `find` | **Yes** |
+| `POSTGRES_USER` | Database user | `find` | **Yes** |
+| `POSTGRES_PASSWORD` | Database password | - | **Yes** |
+
+### Redis / Celery
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `REDIS_URL` | Redis connection URL | `redis://localhost:6379/0` | **Yes** |
+| `CELERY_BROKER_URL` | Celery broker URL | `$REDIS_URL` | No |
+| `CELERY_RESULT_BACKEND` | Celery result backend | `$REDIS_URL` | No |
+
+## Search Backend Configuration
+
+### Backend Selection
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `SEARCH_BACKEND` | Search backend to use | `opensearch` | No |
+| `SEARCH_INDEX_NAME` | Name of the unified index | `find` | No |
+| `SEARCH_DEFAULT_LANGUAGE` | Default search language | `french` | No |
+
+Supported values for `SEARCH_BACKEND`:
+- `opensearch` - OpenSearch 2.x
+- `typesense` - TypeSense 0.25+
+- `meilisearch` - Meilisearch 1.x
+
+### OpenSearch Configuration
+
+Required when `SEARCH_BACKEND=opensearch`:
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `OPENSEARCH_HOST` | OpenSearch hostname | `localhost` | **Yes** |
+| `OPENSEARCH_PORT` | OpenSearch port | `9200` | No |
+| `OPENSEARCH_USE_SSL` | Enable SSL/TLS | `false` | No |
+| `OPENSEARCH_VERIFY_CERTS` | Verify SSL certificates | `true` | No |
+| `OPENSEARCH_USER` | OpenSearch username | - | If auth enabled |
+| `OPENSEARCH_PASSWORD` | OpenSearch password | - | If auth enabled |
+| `OPENSEARCH_CA_CERTS` | Path to CA certificate | - | If custom CA |
+
+### TypeSense Configuration
+
+Required when `SEARCH_BACKEND=typesense`:
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `TYPESENSE_HOST` | TypeSense hostname | `localhost` | **Yes** |
+| `TYPESENSE_PORT` | TypeSense port | `8108` | No |
+| `TYPESENSE_PROTOCOL` | Protocol (http/https) | `http` | No |
+| `TYPESENSE_API_KEY` | TypeSense API key | - | **Yes** |
+
+### Meilisearch Configuration
+
+Required when `SEARCH_BACKEND=meilisearch`:
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `MEILISEARCH_HOST` | Meilisearch hostname | `localhost` | **Yes** |
+| `MEILISEARCH_PORT` | Meilisearch port | `7700` | No |
+| `MEILISEARCH_PROTOCOL` | Protocol (http/https) | `http` | No |
+| `MEILISEARCH_API_KEY` | Meilisearch master key | - | **Yes** |
+
+## Authentication
+
+### OIDC Configuration
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `OIDC_OP_ISSUER` | OIDC provider issuer URL | - | **Yes** |
+| `OIDC_OP_JWKS_ENDPOINT` | JWKS endpoint URL | `{issuer}/.well-known/jwks.json` | No |
+| `OIDC_OP_AUTHORIZATION_ENDPOINT` | Authorization endpoint | Auto-discovered | No |
+| `OIDC_OP_TOKEN_ENDPOINT` | Token endpoint | Auto-discovered | No |
+| `OIDC_OP_USER_ENDPOINT` | Userinfo endpoint | Auto-discovered | No |
+| `OIDC_RP_CLIENT_ID` | Find's OIDC client ID | - | **Yes** |
+| `OIDC_RP_CLIENT_SECRET` | Find's OIDC client secret | - | **Yes** |
+| `OIDC_VERIFY_SSL` | Verify OIDC provider SSL | `true` | No |
+| `OIDC_AUDIENCE` | Expected audience claim | `$OIDC_RP_CLIENT_ID` | No |
+
+### User Claims Mapping
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `OIDC_CLAIM_SUB` | Claim for user identifier | `sub` | No |
+| `OIDC_CLAIM_EMAIL` | Claim for email | `email` | No |
+| `OIDC_CLAIM_GROUPS` | Claim for group memberships | `groups` | No |
+
+## Search Behavior
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `SEARCH_MAX_RESULTS` | Maximum results per search | `100` | No |
+| `SEARCH_DEFAULT_PAGE_SIZE` | Default page size | `20` | No |
+| `SEARCH_HIGHLIGHT_ENABLED` | Enable result highlighting | `true` | No |
+| `SEARCH_HIGHLIGHT_FRAGMENT_SIZE` | Highlight fragment size | `150` | No |
+| `SEARCH_FUZZINESS` | Fuzzy matching level | `AUTO` | No |
+
+## Indexing Behavior
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `INDEX_BATCH_SIZE` | Bulk indexing batch size | `100` | No |
+| `INDEX_REFRESH_INTERVAL` | Index refresh interval | `1s` | No |
+| `INDEX_MAX_CONTENT_LENGTH` | Max document content length | `1000000` | No |
+
+## Observability
+
+### Logging
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `LOG_LEVEL` | Application log level | `INFO` | No |
+| `LOG_FORMAT` | Log format (json/text) | `json` | No |
+
+### Sentry (Error Tracking)
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `SENTRY_DSN` | Sentry DSN | - | No |
+| `SENTRY_ENVIRONMENT` | Sentry environment name | `production` | No |
+| `SENTRY_TRACES_SAMPLE_RATE` | Transaction sampling rate | `0.1` | No |
+
+## Example Configurations
+
+### Development
+
+```bash
+# Core
+DJANGO_DEBUG=true
+DJANGO_SECRET_KEY=dev-secret-key-not-for-production
+
+# Database
+POSTGRES_HOST=localhost
+POSTGRES_PORT=25432
+POSTGRES_DB=find
+POSTGRES_USER=find
+POSTGRES_PASSWORD=find
+
+# Redis
+REDIS_URL=redis://localhost:6379/0
+
+# Search (OpenSearch)
+SEARCH_BACKEND=opensearch
+OPENSEARCH_HOST=localhost
+OPENSEARCH_PORT=9200
+
+# OIDC (local Keycloak)
+OIDC_OP_ISSUER=http://localhost:8080/realms/find
+OIDC_RP_CLIENT_ID=find
+OIDC_RP_CLIENT_SECRET=dev-secret
+```
+
+### Production
+
+```bash
+# Core
+DJANGO_DEBUG=false
+DJANGO_SECRET_KEY=<64-char-random-string>
+DJANGO_ALLOWED_HOSTS=find.example.com
+DJANGO_CSRF_TRUSTED_ORIGINS=https://find.example.com
+
+# Database
+POSTGRES_HOST=postgres.internal
+POSTGRES_PORT=5432
+POSTGRES_DB=find
+POSTGRES_USER=find
+POSTGRES_PASSWORD=<secure-password>
+
+# Redis
+REDIS_URL=redis://redis.internal:6379/0
+
+# Search (OpenSearch with SSL)
+SEARCH_BACKEND=opensearch
+OPENSEARCH_HOST=opensearch.internal
+OPENSEARCH_PORT=9200
+OPENSEARCH_USE_SSL=true
+OPENSEARCH_USER=find
+OPENSEARCH_PASSWORD=<secure-password>
+
+# OIDC
+OIDC_OP_ISSUER=https://auth.example.com/realms/main
+OIDC_RP_CLIENT_ID=find
+OIDC_RP_CLIENT_SECRET=<client-secret>
+
+# Observability
+LOG_LEVEL=INFO
+LOG_FORMAT=json
+SENTRY_DSN=https://xxx@sentry.io/123
+SENTRY_ENVIRONMENT=production
+```
+
+### Using TypeSense
+
+```bash
+SEARCH_BACKEND=typesense
+TYPESENSE_HOST=typesense.internal
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=https
+TYPESENSE_API_KEY=<api-key>
+```
+
+### Using Meilisearch
+
+```bash
+SEARCH_BACKEND=meilisearch
+MEILISEARCH_HOST=meilisearch.internal
+MEILISEARCH_PORT=7700
+MEILISEARCH_PROTOCOL=https
+MEILISEARCH_API_KEY=<master-key>
+```
+
+## Related Documentation
+
+- [Setup Guide](setup-indexer.md) - Installation and deployment
+- [Architecture](architecture.md) - System design
+- [Core Concepts](concepts.md) - Unified index, claims, abstraction

--- a/docs/setup-for-docs.md
+++ b/docs/setup-for-docs.md
@@ -1,39 +1,330 @@
-# Setup the Find search for Impress
+# Integrating Docs with Find
 
-This configuration will enable the fulltext search feature for Docs :
-- Each save on **core.Document** or **core.DocumentAccess** will trigger the indexer
-- The `api/v1.0/documents/search/` will work as a proxy with the Find API for fulltext search.
+This guide explains how to integrate the Docs application with Find for document search.
 
-## Create an index service for Docs
+## Overview
 
-Configure a **Service** for Docs application with these settings
+Docs uses Find to:
+- Index document content for full-text search
+- Search across documents with access control
+- Keep search index synchronized with document changes
 
-- **Name**: `docs`<br>_request.auth.name of the Docs application._
-- **Client id**: `impress`<br>_Name of the token audience or client_id of the Docs application._
+## Prerequisites
 
-See [how-to-use-indexer.md](how-to-use-indexer.md) for details.
+- Find service running and accessible
+- Docs service registered in Find
+- OIDC provider configured for both services
 
-## Configure settings of Docs
+## Service Registration
 
-Add those Django settings the Docs application to enable the feature.
+### 1. Register Docs in Find
 
-```shell
-SEARCH_INDEXER_CLASS="core.services.search_indexers.FindDocumentIndexer"
-SEARCH_INDEXER_COUNTDOWN=10  # Debounce delay in seconds for the indexer calls.
+Create a service entry for Docs in Find:
 
-# The token from service "docs" of Find application (development).
-SEARCH_INDEXER_SECRET="find-api-key-for-docs-with-exactly-50-chars-length"
-SEARCH_INDEXER_URL="http://find:8000/api/v1.0/documents/index/"
+```bash
+# Via Find management command
+python manage.py create_service \
+  --name docs \
+  --client-id docs-oidc-client-id
 
-# Search endpoint. Uses the OIDC token for authentication
-SEARCH_INDEXER_QUERY_URL="http://find:8000/api/v1.0/documents/search/"
+# Output:
+# Service 'docs' created successfully
+# Token: 8f3a9b2c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x
 ```
 
-We also need to enable the **OIDC Token** refresh or the authentication will fail quickly.
+**Save the token securely** - it's required for Docs to authenticate with Find.
 
-```shell
-# Store OIDC tokens in the session
-OIDC_STORE_ACCESS_TOKEN = True  # Store the access token in the session
-OIDC_STORE_REFRESH_TOKEN = True  # Store the encrypted refresh token in the session
-OIDC_STORE_REFRESH_TOKEN_KEY = "your-32-byte-encryption-key=="  # Must be a valid Fernet key (32 url-safe base64-encoded bytes)
+### 2. Configure Docs
+
+Add Find configuration to Docs environment:
+
+```bash
+# Find API endpoint
+FIND_API_URL=https://find.example.com/api/v1.0
+
+# Service token from registration
+FIND_SERVICE_TOKEN=8f3a9b2c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x
 ```
+
+## Indexing Documents
+
+### Document Schema
+
+When indexing a document, Docs sends:
+
+```json
+{
+  "id": "doc-uuid-123",
+  "title": "Meeting Notes - Q1 Planning",
+  "content": "Full document text content...",
+  "path": "/team/planning",
+  "depth": 2,
+  "tags": ["meeting", "planning", "q1"],
+  "users": ["user-sub-alice", "user-sub-bob"],
+  "groups": ["planning-team"],
+  "reach": "restricted",
+  "created_at": "2025-01-15T10:00:00Z",
+  "updated_at": "2025-01-15T14:30:00Z"
+}
+```
+
+### Index API Call
+
+```python
+import requests
+
+def index_document(document):
+    response = requests.post(
+        f"{FIND_API_URL}/documents/index/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}",
+            "Content-Type": "application/json"
+        },
+        json={
+            "id": str(document.id),
+            "title": document.title,
+            "content": document.get_text_content(),
+            "path": document.path,
+            "depth": document.depth,
+            "tags": list(document.tags.values_list("name", flat=True)),
+            "users": document.get_user_subs(),
+            "groups": document.get_group_slugs(),
+            "reach": document.visibility,
+            "created_at": document.created_at.isoformat(),
+            "updated_at": document.updated_at.isoformat()
+        }
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+### Bulk Indexing
+
+For initial sync or large updates:
+
+```python
+def bulk_index_documents(documents):
+    response = requests.post(
+        f"{FIND_API_URL}/documents/index/bulk/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}",
+            "Content-Type": "application/json"
+        },
+        json={
+            "documents": [
+                {
+                    "id": str(doc.id),
+                    "title": doc.title,
+                    "content": doc.get_text_content(),
+                    # ... other fields
+                }
+                for doc in documents
+            ]
+        }
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Searching Documents
+
+### Search Flow
+
+1. User enters search query in Docs UI
+2. Docs forwards request to Find with user's OIDC token
+3. Find filters results based on user's access claims
+4. Docs displays filtered results
+
+### Search API Call
+
+```python
+def search_documents(query, user_token, filters=None):
+    response = requests.post(
+        f"{FIND_API_URL}/documents/search/",
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "Content-Type": "application/json"
+        },
+        json={
+            "query": query,
+            "filters": filters or {},
+            "page": 1,
+            "page_size": 20
+        }
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+### Search Response
+
+```json
+{
+  "count": 42,
+  "results": [
+    {
+      "id": "doc-uuid-123",
+      "title": "Meeting Notes - Q1 Planning",
+      "highlight": {
+        "content": ["...discussed <em>Q1 planning</em> objectives..."]
+      },
+      "score": 12.5
+    }
+  ],
+  "page": 1,
+  "page_size": 20
+}
+```
+
+## Access Control
+
+### Setting Document Permissions
+
+Map Docs permissions to Find access control fields:
+
+| Docs Permission | Find Field | Value |
+|-----------------|------------|-------|
+| Owner | `users` | Owner's SUB |
+| Shared users | `users` | List of user SUBs |
+| Shared groups | `groups` | List of group slugs |
+| Public | `reach` | `"public"` |
+| Team only | `reach` | `"authenticated"` |
+| Private | `reach` | `"restricted"` |
+
+### Example: Shared Document
+
+```python
+def get_access_control(document):
+    users = [document.owner.sub]
+    groups = []
+    reach = "restricted"
+    
+    for share in document.shares.all():
+        if share.share_type == "user":
+            users.append(share.target_user.sub)
+        elif share.share_type == "group":
+            groups.append(share.target_group.slug)
+    
+    if document.is_public:
+        reach = "public"
+    elif document.is_team_visible:
+        reach = "authenticated"
+    
+    return {
+        "users": users,
+        "groups": groups,
+        "reach": reach
+    }
+```
+
+## Synchronization
+
+### Real-time Sync
+
+Index documents on create/update:
+
+```python
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+@receiver(post_save, sender=Document)
+def index_on_save(sender, instance, **kwargs):
+    # Queue async indexing task
+    index_document_task.delay(instance.id)
+
+@receiver(post_delete, sender=Document)
+def delete_on_remove(sender, instance, **kwargs):
+    delete_document_task.delay(instance.id)
+```
+
+### Batch Sync
+
+Periodic full sync for consistency:
+
+```python
+from celery import shared_task
+
+@shared_task
+def full_sync():
+    documents = Document.objects.filter(is_active=True)
+    for batch in chunked(documents, 100):
+        bulk_index_documents(batch)
+```
+
+## Deleting Documents
+
+### Single Document
+
+```python
+def delete_document(document_id):
+    response = requests.delete(
+        f"{FIND_API_URL}/documents/{document_id}/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}"
+        }
+    )
+    response.raise_for_status()
+```
+
+### By Tags
+
+```python
+def delete_by_tags(tags):
+    response = requests.post(
+        f"{FIND_API_URL}/documents/delete/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}",
+            "Content-Type": "application/json"
+        },
+        json={"tags": tags}
+    )
+    response.raise_for_status()
+```
+
+## Error Handling
+
+### Retry Logic
+
+```python
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10)
+)
+def index_with_retry(document):
+    return index_document(document)
+```
+
+### Error Responses
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 400 | Invalid document schema | Fix document data |
+| 401 | Invalid service token | Check FIND_SERVICE_TOKEN |
+| 404 | Document not found (delete) | Already deleted, ignore |
+| 503 | Find unavailable | Retry with backoff |
+
+## Monitoring
+
+### Health Check
+
+```python
+def check_find_health():
+    response = requests.get(f"{FIND_API_URL}/health/")
+    return response.status_code == 200
+```
+
+### Metrics to Track
+
+- Index latency (p95, p99)
+- Search latency (p95, p99)
+- Index error rate
+- Search error rate
+- Documents indexed per minute
+
+## Related Documentation
+
+- [Core Concepts](concepts.md) - Unified index, claims, abstraction
+- [Setup Guide](setup-indexer.md) - Find configuration
+- [Environment Variables](env.md) - Configuration reference

--- a/docs/setup-for-drive.md
+++ b/docs/setup-for-drive.md
@@ -1,43 +1,423 @@
-# Setup the Find search for Drive
+# Integrating Drive with Find
 
-This configuration will enable the fulltext search feature for Docs :
-- Each save on **core.Item** or **core.Item** will trigger the indexer
-- Once indexer service configured, the `api/v1.0/item/search/` will work as a proxy with the Find API for fulltext search.
+This guide explains how to integrate the Drive application with Find for file search.
 
-## Create an index service for Drive
+## Overview
 
-Configure a **Service** for Docs application with these settings
+Drive uses Find to:
+- Index file metadata and content for full-text search
+- Search across files with folder-based access control
+- Keep search index synchronized with file changes
 
-- **Name**: `drive`<br>_request.auth.name of the Docs application._
-- **Client id**: `drive`<br>_Name of the token audience or client_id of the Docs application._
+## Prerequisites
 
-See [how-to-use-indexer.md](how-to-use-indexer.md) for details.
+- Find service running and accessible
+- Drive service registered in Find
+- OIDC provider configured for both services
 
-## Configure settings of Drive
+## Service Registration
 
-Add those Django settings the Docs application to enable the feature.
+### 1. Register Drive in Find
+
+Create a service entry for Drive in Find:
+
+```bash
+# Via Find management command
+python manage.py create_service \
+  --name drive \
+  --client-id drive-oidc-client-id
+
+# Output:
+# Service 'drive' created successfully
+# Token: 9g4b0c3d5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z
+```
+
+**Save the token securely** - it's required for Drive to authenticate with Find.
+
+### 2. Configure Drive
+
+Add Find configuration to Drive environment:
+
+```bash
+# Find API endpoint
+FIND_API_URL=https://find.example.com/api/v1.0
+
+# Service token from registration
+FIND_SERVICE_TOKEN=9g4b0c3d5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z
+```
+
+## Indexing Files
+
+### File Schema
+
+When indexing a file, Drive sends:
+
+```json
+{
+  "id": "file-uuid-456",
+  "title": "Q1 Financial Report.pdf",
+  "content": "Extracted text content from PDF...",
+  "path": "/Finance/Reports/2025",
+  "depth": 3,
+  "size": 2048576,
+  "tags": ["finance", "report", "q1"],
+  "users": ["user-sub-charlie"],
+  "groups": ["finance-team"],
+  "reach": "restricted",
+  "created_at": "2025-01-20T09:00:00Z",
+  "updated_at": "2025-01-20T09:00:00Z"
+}
+```
+
+### Content Extraction
+
+Extract searchable text from files before indexing:
 
 ```python
-SEARCH_INDEXER_CLASS="core.services.search_indexers.SearchIndexer"
-SEARCH_INDEXER_COUNTDOWN=10  # Debounce delay in seconds for the indexer calls.
-
-# The token from service "drive" of Find application (development)
-SEARCH_INDEXER_SECRET=find-api-key-for-driv-with-exactly-50-chars-length
-SEARCH_INDEXER_URL="http://find:8000/api/v1.0/documents/index/"
-
-# Search endpoint. Uses the OIDC token for authentication
-SEARCH_INDEXER_QUERY_URL="http://find:8000/api/v1.0/documents/search/"
-
-# Limit the mimetypes and size of indexable files
-SEARCH_INDEXER_ALLOWED_MIMETYPES=["text/"]
-SEARCH_INDEXER_UPLOAD_MAX_SIZE=2 * 2**20  # 2Mb
+def extract_content(file):
+    """Extract text content based on file type."""
+    if file.mime_type == "application/pdf":
+        return extract_pdf_text(file.path)
+    elif file.mime_type in ["application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"]:
+        return extract_docx_text(file.path)
+    elif file.mime_type.startswith("text/"):
+        return file.read_text()
+    else:
+        # Non-text files: index metadata only
+        return ""
 ```
 
-We also need to enable the **OIDC Token** refresh or the authentication will fail quickly.
+### Index API Call
 
-```shell
-# Store OIDC tokens in the session
-OIDC_STORE_ACCESS_TOKEN = True  # Store the access token in the session
-OIDC_STORE_REFRESH_TOKEN = True  # Store the encrypted refresh token in the session
-OIDC_STORE_REFRESH_TOKEN_KEY = "your-32-byte-encryption-key=="  # Must be a valid Fernet key (32 url-safe base64-encoded bytes)
+```python
+import requests
+
+def index_file(file):
+    response = requests.post(
+        f"{FIND_API_URL}/documents/index/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}",
+            "Content-Type": "application/json"
+        },
+        json={
+            "id": str(file.id),
+            "title": file.name,
+            "content": extract_content(file),
+            "path": file.folder_path,
+            "depth": file.depth,
+            "size": file.size,
+            "tags": list(file.tags.values_list("name", flat=True)),
+            "users": file.get_user_subs(),
+            "groups": file.get_group_slugs(),
+            "reach": file.visibility,
+            "created_at": file.created_at.isoformat(),
+            "updated_at": file.updated_at.isoformat()
+        }
+    )
+    response.raise_for_status()
+    return response.json()
 ```
+
+### Bulk Indexing
+
+For initial sync or folder moves:
+
+```python
+def bulk_index_files(files):
+    response = requests.post(
+        f"{FIND_API_URL}/documents/index/bulk/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}",
+            "Content-Type": "application/json"
+        },
+        json={
+            "documents": [
+                {
+                    "id": str(f.id),
+                    "title": f.name,
+                    "content": extract_content(f),
+                    # ... other fields
+                }
+                for f in files
+            ]
+        }
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Searching Files
+
+### Search Flow
+
+1. User enters search query in Drive UI
+2. Drive forwards request to Find with user's OIDC token
+3. Find filters results based on user's access claims
+4. Drive displays filtered results with file icons and paths
+
+### Search API Call
+
+```python
+def search_files(query, user_token, folder_path=None):
+    filters = {}
+    if folder_path:
+        filters["path_prefix"] = folder_path
+    
+    response = requests.post(
+        f"{FIND_API_URL}/documents/search/",
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "Content-Type": "application/json"
+        },
+        json={
+            "query": query,
+            "filters": filters,
+            "page": 1,
+            "page_size": 20
+        }
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+### Search Response
+
+```json
+{
+  "count": 15,
+  "results": [
+    {
+      "id": "file-uuid-456",
+      "title": "Q1 Financial Report.pdf",
+      "path": "/Finance/Reports/2025",
+      "highlight": {
+        "content": ["...revenue increased by <em>15%</em> in Q1..."]
+      },
+      "score": 8.2
+    }
+  ],
+  "page": 1,
+  "page_size": 20
+}
+```
+
+## Access Control
+
+### Folder-Based Permissions
+
+Drive uses folder hierarchy for permissions. Map to Find access control:
+
+```python
+def get_access_control(file):
+    """
+    Collect permissions from file and parent folders.
+    Users/groups with access to parent folder have access to file.
+    """
+    users = set()
+    groups = set()
+    
+    # File owner always has access
+    users.add(file.owner.sub)
+    
+    # Direct file shares
+    for share in file.shares.all():
+        if share.share_type == "user":
+            users.add(share.target_user.sub)
+        elif share.share_type == "group":
+            groups.add(share.target_group.slug)
+    
+    # Inherited folder permissions
+    folder = file.parent_folder
+    while folder:
+        for share in folder.shares.all():
+            if share.share_type == "user":
+                users.add(share.target_user.sub)
+            elif share.share_type == "group":
+                groups.add(share.target_group.slug)
+        folder = folder.parent_folder
+    
+    # Determine reach level
+    if file.is_public or any(f.is_public for f in file.ancestor_folders):
+        reach = "public"
+    elif file.is_team_visible:
+        reach = "authenticated"
+    else:
+        reach = "restricted"
+    
+    return {
+        "users": list(users),
+        "groups": list(groups),
+        "reach": reach
+    }
+```
+
+### Permission Changes
+
+When folder permissions change, reindex all contained files:
+
+```python
+def on_folder_permission_change(folder):
+    """Reindex all files in folder and subfolders."""
+    files = File.objects.filter(
+        path__startswith=folder.path
+    ).select_related("owner")
+    
+    bulk_index_files(files)
+```
+
+## Synchronization
+
+### Real-time Sync
+
+Index files on create/update/move:
+
+```python
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+@receiver(post_save, sender=File)
+def index_on_save(sender, instance, **kwargs):
+    index_file_task.delay(instance.id)
+
+@receiver(post_delete, sender=File)
+def delete_on_remove(sender, instance, **kwargs):
+    delete_file_task.delay(instance.id)
+```
+
+### File Move Handling
+
+When files move between folders:
+
+```python
+def on_file_move(file, old_path, new_path):
+    """
+    Reindex file with new path and permissions.
+    Permissions may change based on new parent folder.
+    """
+    index_file(file)
+```
+
+### Folder Move Handling
+
+When folders move, reindex all contents:
+
+```python
+def on_folder_move(folder, old_path, new_path):
+    """Reindex all files in moved folder."""
+    files = File.objects.filter(path__startswith=new_path)
+    bulk_index_files(files)
+```
+
+## Large File Handling
+
+### Content Size Limits
+
+For large files, truncate content:
+
+```python
+MAX_CONTENT_LENGTH = 1_000_000  # 1MB
+
+def extract_content_safe(file):
+    content = extract_content(file)
+    if len(content) > MAX_CONTENT_LENGTH:
+        content = content[:MAX_CONTENT_LENGTH]
+    return content
+```
+
+### Async Content Extraction
+
+Extract content asynchronously for large files:
+
+```python
+from celery import shared_task
+
+@shared_task
+def extract_and_index(file_id):
+    file = File.objects.get(id=file_id)
+    content = extract_content(file)
+    index_file(file, content=content)
+```
+
+## Deleting Files
+
+### Single File
+
+```python
+def delete_file_from_index(file_id):
+    response = requests.delete(
+        f"{FIND_API_URL}/documents/{file_id}/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}"
+        }
+    )
+    if response.status_code != 404:
+        response.raise_for_status()
+```
+
+### Folder Deletion
+
+When deleting a folder, delete all contained files:
+
+```python
+def delete_folder_from_index(folder_path):
+    """Delete all files under a folder path."""
+    response = requests.post(
+        f"{FIND_API_URL}/documents/delete/",
+        headers={
+            "Authorization": f"Token {FIND_SERVICE_TOKEN}",
+            "Content-Type": "application/json"
+        },
+        json={"path_prefix": folder_path}
+    )
+    response.raise_for_status()
+```
+
+## Error Handling
+
+### Content Extraction Errors
+
+```python
+def safe_extract_content(file):
+    try:
+        return extract_content(file)
+    except Exception as e:
+        logger.warning(f"Content extraction failed for {file.id}: {e}")
+        return ""  # Index with metadata only
+```
+
+### Retry Logic
+
+```python
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10)
+)
+def index_with_retry(file):
+    return index_file(file)
+```
+
+## Monitoring
+
+### Health Check
+
+```python
+def check_find_health():
+    response = requests.get(f"{FIND_API_URL}/health/")
+    return response.status_code == 200
+```
+
+### Metrics to Track
+
+- Index latency by file type
+- Content extraction time
+- Search latency (p95, p99)
+- Index error rate by file type
+- Files indexed per minute
+
+## Related Documentation
+
+- [Core Concepts](concepts.md) - Unified index, claims, abstraction
+- [Setup Guide](setup-indexer.md) - Find configuration
+- [Environment Variables](env.md) - Configuration reference

--- a/docs/setup-indexer.md
+++ b/docs/setup-indexer.md
@@ -1,128 +1,287 @@
-# Using the Find indexer
+# Setting Up Find
 
-This guide explains how to setup the Find service which provide an API for indexation and fulltext search of
-documents from various sources in a secure way : only the documents within the scope of the user's OIDC token
-are visible.
+This guide covers deploying and configuring Find for your environment.
 
-## Setup Opensearch
+## Prerequisites
 
-### General
+- Python 3.11+
+- PostgreSQL 14+
+- Redis 7+
+- One of: OpenSearch 2.x, TypeSense 0.25+, or Meilisearch 1.x
+- Docker & Docker Compose (for development)
 
-Add the following variables to your Django settings to configure Find and enable full-text search.
+## Quick Start (Development)
 
-```python
-# Login for opensearch
-OPENSEARCH_USER=opensearch-user
-OPENSEARCH_PASSWORD=your-opensearch-password
+```bash
+# Clone the repository
+git clone https://github.com/suitenumerique/find.git
+cd find
 
-# Host configuration
-OPENSEARCH_HOST=opensearch
+# Copy environment file
+cp env.d/development/common.dist.env env.d/development/common.env
+
+# Start services
+make bootstrap
+
+# Run migrations
+make migrate
+
+# Create the unified index
+make create-index
+```
+
+Find is now running at `http://localhost:8081`.
+
+## Configuration
+
+### Search Backend Selection
+
+Find supports multiple search backends. Set the `SEARCH_BACKEND` environment variable:
+
+```bash
+# OpenSearch (default)
+SEARCH_BACKEND=opensearch
+
+# TypeSense
+SEARCH_BACKEND=typesense
+
+# Meilisearch
+SEARCH_BACKEND=meilisearch
+```
+
+Each backend requires its own configuration. See [Environment Variables](env.md) for details.
+
+### Database Configuration
+
+```bash
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=find
+POSTGRES_USER=find
+POSTGRES_PASSWORD=<secure-password>
+```
+
+### Redis Configuration
+
+```bash
+REDIS_URL=redis://localhost:6379/0
+```
+
+## Unified Index
+
+Find uses a single unified index for all documents. The index is created automatically on first startup, or manually:
+
+```bash
+# Create the index with proper mappings
+make create-index
+
+# Or via Django management command
+python manage.py create_index
+```
+
+### Index Structure
+
+The unified index contains documents from all services:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "id": { "type": "keyword" },
+      "service": { "type": "keyword" },
+      "title": { "type": "text", "analyzer": "french" },
+      "content": { "type": "text", "analyzer": "french" },
+      "users": { "type": "keyword" },
+      "groups": { "type": "keyword" },
+      "reach": { "type": "keyword" },
+      "tags": { "type": "keyword" },
+      "path": { "type": "keyword" },
+      "depth": { "type": "integer" },
+      "is_active": { "type": "boolean" },
+      "created_at": { "type": "date" },
+      "updated_at": { "type": "date" }
+    }
+  }
+}
+```
+
+### Language Support
+
+Find supports multiple languages with appropriate analyzers:
+
+| Language | Analyzer |
+|----------|----------|
+| French | `french` with elision, stopwords |
+| English | `english` with stemming |
+| German | `german` with compound words |
+| Dutch | `dutch` with stemming |
+
+Configure the default language:
+
+```bash
+SEARCH_DEFAULT_LANGUAGE=french
+```
+
+## Service Registration
+
+Services (applications) must be registered before they can index documents.
+
+### Create a Service
+
+```bash
+# Via Django admin
+python manage.py createsuperuser
+# Then visit http://localhost:8081/admin/core/service/
+
+# Or via management command
+python manage.py create_service --name docs --client-id docs-client-id
+```
+
+### Service Token
+
+Each service receives a 50-character token for authentication:
+
+```
+Token: 8f3a9b2c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x
+```
+
+**Keep this token secure.** It grants full write access to documents for that service.
+
+### Service Configuration
+
+| Field | Description |
+|-------|-------------|
+| `name` | Service identifier (e.g., "docs", "drive") |
+| `client_id` | OIDC client ID for the service |
+| `token` | Authentication token for indexing API |
+| `is_active` | Enable/disable the service |
+
+## Access Control Setup
+
+Documents are indexed with access control fields that determine who can search them.
+
+### Access Control Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `users` | array | User SUBs who can access |
+| `groups` | array | Group slugs who can access |
+| `reach` | string | Visibility level |
+
+### Reach Levels
+
+| Value | Who Can See |
+|-------|-------------|
+| `public` | Anyone (requires explicit visit) |
+| `authenticated` | Any authenticated user (requires explicit visit) |
+| `restricted` | Only users in `users` or `groups` |
+
+### Example Document with Access Control
+
+```json
+{
+  "id": "doc-123",
+  "service": "docs",
+  "title": "Project Roadmap",
+  "content": "Q1 objectives...",
+  "users": ["user-sub-alice", "user-sub-bob"],
+  "groups": ["engineering-team"],
+  "reach": "restricted"
+}
+```
+
+This document is visible only to:
+- Users with SUB `user-sub-alice` or `user-sub-bob`
+- Users who are members of `engineering-team` group
+
+## Health Checks
+
+Find exposes health check endpoints:
+
+```bash
+# Overall health
+curl http://localhost:8081/api/v1.0/health/
+
+# Search backend health
+curl http://localhost:8081/api/v1.0/health/search/
+```
+
+## Production Deployment
+
+### Environment Variables
+
+For production, ensure these are set:
+
+```bash
+# Security
+DJANGO_SECRET_KEY=<cryptographically-secure-key>
+DJANGO_ALLOWED_HOSTS=find.example.com
+DJANGO_CSRF_TRUSTED_ORIGINS=https://find.example.com
+
+# Search Backend
+SEARCH_BACKEND=opensearch
+OPENSEARCH_HOST=opensearch.internal
 OPENSEARCH_PORT=9200
+OPENSEARCH_USE_SSL=true
 
-# Enable SSL for opensearch connection (False in dev mode)
-OPENSEARCH_USE_SSL=True
+# Database
+POSTGRES_HOST=postgres.internal
+POSTGRES_PASSWORD=<secure-password>
 
-# Prefix for the index name of the registered services.
-OPENSEARCH_INDEX_PREFIX=find
+# Redis
+REDIS_URL=redis://redis.internal:6379/0
 ```
 
-### Language
+See [Environment Variables](env.md) for complete reference.
 
-Language specific operations are applied to document titles and contents to improve search results. 
-The language is automatically detected  by Find.
-If the language can not be detected no language specific operation are applied and the indexing process is not affected.
+### Scaling
 
-Find supports french, english, german and dutch. 
+| Component | Scaling Strategy |
+|-----------|-----------------|
+| **API** | Horizontal (multiple replicas behind load balancer) |
+| **Celery Workers** | Horizontal (increase for indexing throughput) |
+| **Search Backend** | Per backend documentation (cluster mode) |
+| **PostgreSQL** | Vertical (or managed service with replicas) |
+| **Redis** | Vertical (or Redis Cluster for high availability) |
 
-The search process is not language specific, a query can get documents of any language.
+### Monitoring
 
-Language detection estimates a confidence between 0 and 1. If the confidence is below a threshold the language is considered unrecognized. 
-This threshold can be controlled with LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD environment variable.
+Key metrics to monitor:
 
-```python
-LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD=0.75
+- API response times (p50, p95, p99)
+- Search query latency
+- Indexing queue depth (Celery)
+- Search backend health
+- Document count by service
+
+## Troubleshooting
+
+### Index Not Created
+
+```bash
+# Check search backend connectivity
+curl http://localhost:9200/_cluster/health
+
+# Recreate index
+make create-index
 ```
 
-## trigrams
+### Service Cannot Index
 
-Find uses trigrams to improve the robustness of the full text search engine to spelling variations and errors. It can be configured by two environment variables. 
+1. Verify service token is correct
+2. Check service is active in database
+3. Verify search backend is healthy
 
-````
-TRIGRAMS_BOOST=0.25
-TRIGRAMS_MINIMUM_SHOULD_MATCH=0.75%
-````
+### Search Returns No Results
 
-`TRIGRAMS_BOOST` is weight boost applied to the trigram score in the document matching. 
-`TRIGRAMS_MINIMUM_SHOULD_MATCH` is the minimal number or proportion of trigrams having to match to score. It is
-either an absolute number or proportion.
+1. Verify documents are indexed: `GET /api/v1.0/documents/count/`
+2. Check user has access (correct SUB, group membership)
+3. Verify `reach` level is appropriate
 
-## Setup indexation API
+## Next Steps
 
-Other applications can index their files through the **`/index/`** endpoint with a simple token authentication.
-
-For each application a new **Service** must be created through the admin interface
-(see http://localhost:9071/admin/core/service/add/)
-
-| Field                       | Description                                        |
-|-----------------------------|----------------------------------------------------|
-| Name                        | Name of the service and also the name of the index in Opensearch database |
-| Is active                   | Toggle service availability                        |
-| Client id                   | Calling service client_id (e.g `impress` for docs) |
-| Allowed services for search | List of sub-services. Will add the results from all these index<br>to the search results. |
-| Token (_read-only_)         | Random token for calling service authentication    |
-
-And add the key in the calling application Django settings.
-
-**Development Mode (Docs + Find)**
-
-The command `make demo` will create a working service configuration for `docs` and `drive` with predefined secret keys
-
-```python
-# Docs
-SEARCH_INDEXER_SECRET="find-api-key-for-docs-with-exactly-50-chars-length"
-```
-
-```python
-# Drive
-SEARCH_INDEXER_SECRET="find-api-key-for-driv-with-exactly-50-chars-length"
-```
-
-## Setup search API
-
-The **`/search/`** endpoint is an OIDC ResourceServer view and needs extra Django settings (see [lasuite](https://github.com/suitenumerique/django-lasuite/blob/main/documentation/how-to-use-oidc-resource-server-backend.md) for details)
-
-```shell
-OIDC_OP_JWKS_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/certs
-OIDC_OP_AUTHORIZATION_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/auth
-OIDC_OP_TOKEN_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/token
-OIDC_OP_USER_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/userinfo
-
-# To run Find in development mode along other projects like docs/impress
-# we should to use OIDC endpoints on a common keycloak realm. e.g :
-# OIDC_OP_URL = http://nginx:8083/realms/impress
-#
-# This will cause a conflict with the 'iss' claim validation rule because the docs realm
-# gives {'iss': 'http://localhost:8083/realms/impress'} so it must be the same
-OIDC_OP_URL=http://localhost:8083/realms/impress
-
-# Introspection endpoint is needed to get the "audience" and "sub" from the user token
-OIDC_OP_INTROSPECTION_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/token/introspect
-
-# In development, the resource server use insecure settings
-# OIDC_VERIFY_SSL=False
-
-# Resource server
-OIDC_RS_SCOPES="openid"
-OIDC_RS_SIGN_ALGO=RS256
-
-# This backend allows authentication without any model in database. 
-OIDC_RS_BACKEND_CLASS="core.authentication.FinderResourceServerBackend"
-```
-
-**Development mode (Docs + Find)**
-
-Docs and Find projects stacks can be run together but must have the same keycloak server.
-
-So the endpoints of Docs on the 'nginx' domain for ResourceServer authentication and introspection are also used for Find.
-
-**IMPORTANT:** Keep OIDC_OP_URL on 'localhost' or it will break the OIDC token claims validation : the `iss` claim from the token of the 'impress' users are 'localhost' and not 'nginx'.
+- [Core Concepts](concepts.md) - Understand unified index, claims, abstraction
+- [Architecture](architecture.md) - System architecture overview
+- [Integration: Docs](setup-for-docs.md) - Integrate with Docs application
+- [Integration: Drive](setup-for-drive.md) - Integrate with Drive application
+- [Environment Variables](env.md) - Complete configuration reference


### PR DESCRIPTION
## Summary

- Rewrite all documentation to reflect new unified index architecture
- Add `docs/concepts.md` as foundational reference explaining core concepts
- Update architecture diagrams with abstraction layer and claims model
- Remove references to per-service indices (`find-docs`, `find-drive`)

## Key Changes

| Concept | Old | New |
|---------|-----|-----|
| Index structure | Per-service (`find-docs`, `find-drive`) | Unified (single index with `service` field) |
| Service isolation | Separate indices | Query-time filtering by `service` |
| Backend coupling | OpenSearch-specific | Abstraction layer (OpenSearch/TypeSense/Meilisearch) |
| Config | `OPENSEARCH_INDEX_PREFIX` | `SEARCH_BACKEND` + per-backend config |

## Files Changed

- **NEW** `docs/concepts.md` - Core concepts (unified index, claims, abstraction)
- `docs/architecture.md` - New mermaid diagrams
- `docs/setup-indexer.md` - Unified index setup
- `docs/env.md` - Backend-agnostic env vars
- `docs/setup-for-docs.md` - Updated integration guide
- `docs/setup-for-drive.md` - Updated integration guide
- `README.md` - New project overview