### PR TITLE
Unify indices with service field scoping

### DIFF
--- a/docs/setup-indexer.md
+++ b/docs/setup-indexer.md
@@ -23,8 +23,8 @@ OPENSEARCH_PORT=9200
 # Enable SSL for opensearch connection (False in dev mode)
 OPENSEARCH_USE_SSL=True
 
-# Prefix for the index name of the registered services.
-OPENSEARCH_INDEX_PREFIX=find
+# Unified index name for all services
+OPENSEARCH_INDEX=find
 ```
 
 ### Language
@@ -64,13 +64,13 @@ Other applications can index their files through the **`/index/`** endpoint with
 For each application a new **Service** must be created through the admin interface
 (see http://localhost:9071/admin/core/service/add/)
 
-| Field                       | Description                                                                               |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| Name                        | Name of the service and also the name of the index in Opensearch database                 |
-| Is active                   | Toggle service availability                                                               |
-| Client id                   | Calling service client_id (e.g `impress` for docs)                                        |
-| Allowed services for search | List of sub-services. Will add the results from all these index<br>to the search results. |
-| Token (_read-only_)         | Random token for calling service authentication                                           |
+| Field                       | Description                                        |
+|-----------------------------|----------------------------------------------------|
+| Name                        | Name of the service (used as `service` field) |
+| Is active                   | Toggle service availability                        |
+| Client id                   | Calling service client_id (e.g `impress` for docs) |
+| Allowed services for search | List of sub-services. Will add the results from all these services<br>to the search results. |
+| Token (_read-only_)         | Random token for calling service authentication    |
 
 And add the key in the calling application Django settings.
 

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -15,7 +15,7 @@ FIND_BASE_URL="http://localhost:8072"
 # Opensearch
 OPENSEARCH_PASSWORD=find.PASS123
 OPENSEARCH_USE_SSL=false
-OPENSEARCH_INDEX_PREFIX=find
+OPENSEARCH_INDEX=find
 
 # OIDC
 OIDC_OP_JWKS_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/certs

--- a/src/backend/core/api.py
+++ b/src/backend/core/api.py
@@ -2,6 +2,7 @@
 
 from django.core.exceptions import ValidationError
 
+from opensearchpy.exceptions import NotFoundError as OpenSearchNotFoundError
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import exceptions as drf_exceptions
 from rest_framework import status
@@ -32,6 +33,12 @@ def exception_handler(exc, context):
                 for error in exc.errors()
             ],
             status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    elif isinstance(exc, OpenSearchNotFoundError):
+        return Response(
+            {"detail": "Search index not found. Please contact administrator."},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
 
     return drf_views.exception_handler(exc, context)

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -13,7 +13,7 @@ from . import enums, models
 fake = Faker()
 
 
-class DocumentSchemaFactory(factory.DictFactory):
+class DocumentFactory(factory.DictFactory):
     """
     A factory for generating dictionaries that represent a document for
     indexation for testing and development purposes.

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -3,21 +3,14 @@
 import secrets
 import string
 
-from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.db.models.functions import Length
-from django.utils.functional import cached_property
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
 models.CharField.register_lookup(Length)
 TOKEN_LENGTH = 50
-
-
-def get_opensearch_index_name(name: str):
-    """Returns the opensearch index for a service name"""
-    return f"{settings.OPENSEARCH_INDEX_PREFIX}-{name}"
 
 
 class User(AbstractUser):
@@ -68,8 +61,3 @@ class Service(models.Model):
         )
         token = "".join(secrets.choice(characters) for _ in range(TOKEN_LENGTH))
         return token
-
-    @cached_property
-    def index_name(self):
-        """Returns the opensearch index for the service"""
-        return get_opensearch_index_name(self.name)

--- a/src/backend/core/schemas.py
+++ b/src/backend/core/schemas.py
@@ -20,7 +20,7 @@ from pydantic import (
 from . import enums
 
 
-class DocumentSchema(BaseModel):
+class Document(BaseModel):
     """Schema for validating the documents submitted to our API for indexing"""
 
     id: UUID4
@@ -106,11 +106,10 @@ def cleanlist(value):
 StringListParameter = Annotated[List[str], BeforeValidator(cleanlist)]
 
 
-class SearchQueryParametersSchema(BaseModel):
+class SearchQueryParameters(BaseModel):
     """Schema for validating the querystring on the search API endpoint"""
 
     q: str
-    services: StringListParameter = Field(default_factory=list)
     visited: StringListParameter = Field(default_factory=list)
     reach: Optional[enums.ReachEnum] = None
     tags: StringListParameter = Field(default_factory=list)
@@ -120,10 +119,9 @@ class SearchQueryParametersSchema(BaseModel):
     nb_results: Optional[conint(ge=1, le=300)] = Field(default=50)
 
 
-class DeleteDocumentsSchema(BaseModel):
+class DeleteDocuments(BaseModel):
     """Schema for validating the delete documents request"""
 
-    service: str = Field(max_length=300)
     document_ids: Optional[List[str]] = Field(default=None)
     tags: Optional[List[str]] = Field(default=None)
 

--- a/src/backend/core/services/indexing.py
+++ b/src/backend/core/services/indexing.py
@@ -3,7 +3,6 @@
 import logging
 
 from django.conf import settings
-from django.core.exceptions import SuspiciousOperation
 
 from opensearchpy.exceptions import NotFoundError
 from py3langid.langid import MODEL_FILE, LanguageIdentifier
@@ -14,7 +13,6 @@ from core.services.opensearch_configuration import (
     MAPPINGS,
 )
 
-from ..models import Service, get_opensearch_index_name
 from .opensearch import opensearch_client
 
 logger = logging.getLogger(__name__)
@@ -45,11 +43,12 @@ def ensure_index_exists(index_name):
         )
 
 
-def prepare_document_for_indexing(document):
-    """Prepare document for indexing using nested language structure"""
+def prepare_document_for_indexing(document, service_name):
+    """Prepare document for indexing using nested language structure."""
     language_code = detect_language_code(f"{document['title']} {document['content']}")
     return {
         "id": document["id"],
+        "service": service_name,
         f"title.{language_code}": document["title"],
         f"content.{language_code}": document["content"],
         "depth": document["depth"],
@@ -75,26 +74,3 @@ def detect_language_code(text):
         return settings.UNDETERMINED_LANGUAGE_CODE
 
     return detected_code
-
-
-def get_opensearch_indices(audience, services):
-    """
-    Get OpenSearch indices for the given audience and services.
-    """
-    try:
-        user_service = Service.objects.get(client_id=audience, is_active=True)
-    except Service.DoesNotExist as e:
-        logger.warning("Login failed: No service %s found", audience)
-        raise SuspiciousOperation("Service is not available") from e
-
-    # Find allowed sub-services for this service
-    allowed_services = set(user_service.services.values_list("name", flat=True))
-    allowed_services.add(user_service.name)
-
-    if services:
-        available_service = set(services).intersection(allowed_services)
-
-        if len(available_service) < len(services):
-            raise SuspiciousOperation("Some requested services are not available")
-
-    return [get_opensearch_index_name(service) for service in allowed_services]

--- a/src/backend/core/services/opensearch_configuration.py
+++ b/src/backend/core/services/opensearch_configuration.py
@@ -266,6 +266,7 @@ MAPPINGS = {
         "users": {"type": "keyword"},
         "groups": {"type": "keyword"},
         "reach": {"type": "keyword"},
+        "service": {"type": "keyword"},
         "tags": {"type": "keyword"},
         "is_active": {"type": "boolean"},
     },

--- a/src/backend/core/tests/conftest.py
+++ b/src/backend/core/tests/conftest.py
@@ -12,12 +12,11 @@ fake = Faker()
 @pytest.fixture(autouse=True)
 def cleanup_test_index(settings):
     """
-    Fixture to set a randomized prefix for all service indexes within the tests
-    and remove them on tear down.
+    Fixture to set a randomized index name for tests and remove it on tear down.
     """
-    _original_prefix = settings.OPENSEARCH_INDEX_PREFIX
-    prefix = "".join(fake.random_letters(5)).lower()
-    settings.OPENSEARCH_INDEX_PREFIX = prefix
+    original_index = settings.OPENSEARCH_INDEX
+    test_index = "".join(fake.random_letters(5)).lower()
+    settings.OPENSEARCH_INDEX = test_index
 
     # Create client here to prevent "teardown" issues when the opensearch settings are
     # removed for error tests.
@@ -25,9 +24,9 @@ def cleanup_test_index(settings):
 
     yield
 
-    settings.OPENSEARCH_INDEX_PREFIX = _original_prefix
+    settings.OPENSEARCH_INDEX = original_index
 
     try:
-        client.indices.delete(index=f"{prefix}-*")
+        client.indices.delete(index=test_index)
     except NotFoundError:
         pass

--- a/src/backend/core/tests/test_api_documents_delete.py
+++ b/src/backend/core/tests/test_api_documents_delete.py
@@ -1,24 +1,58 @@
 """Tests for deleting documents from OpenSearch over the API"""
 
+import logging
+from typing import List
+
 import opensearchpy
 import pytest
 import responses
+from opensearchpy.helpers import bulk
 from rest_framework.test import APIClient
 
 from core import factories
+from core.services.indexing import ensure_index_exists, prepare_document_for_indexing
 from core.services.opensearch import opensearch_client
-from core.utils import prepare_index
 
 from .utils import build_authorization_bearer, setup_oicd_resource_server
 
+logger = logging.getLogger(__name__)
+
 pytestmark = pytest.mark.django_db
+
+
+def prepare_index(
+    index_name: str, documents: List[dict], service_name: str = "test-service"
+):
+    """Prepare the search index before testing a query on it.
+
+    Args:
+        index_name: The OpenSearch index name.
+        documents: List of documents to index.
+        service_name: Service name to assign to documents.
+    """
+    logger.info("Preparing index %s with %d documents", index_name, len(documents))
+
+    client = opensearch_client()
+    ensure_index_exists(index_name)
+    if documents:
+        actions = [
+            {
+                "_op_type": "index",
+                "_index": index_name,
+                "_id": document["id"],
+                "_source": prepare_document_for_indexing(document, service_name),
+            }
+            for document in documents
+        ]
+        bulk(client, actions)
+    client.indices.refresh(index=index_name)
 
 
 def test_api_documents_delete_anonymous():
     """Anonymous requests should not be allowed to delete documents."""
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": "service-name", "document_ids": ["doc1"]},
+        {"document_ids": ["doc1"]},
         format="json",
     )
 
@@ -29,35 +63,19 @@ def test_api_documents_delete_anonymous():
 
 
 @responses.activate
-def test_api_documents_delete_wrong_service_name(settings):
-    """Requests with a wrong service name should return 400 Bad Request."""
-    setup_oicd_resource_server(responses, settings, sub="user_sub")
-
-    response = APIClient().post(
-        "/api/v1.0/documents/delete/",
-        {"service": "wrong-service", "document_ids": ["0"]},
-        format="json",
-        HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
-    )
-
-    assert response.status_code == 400
-    assert response.json() == {"detail": "Invalid request."}
-
-
-@responses.activate
 def test_api_documents_delete_success(settings):
     """Authenticated users should be able to delete documents they have access to."""
     setup_oicd_resource_server(responses, settings, sub="user_sub")
 
     service = factories.ServiceFactory()
     # Create documents user has access to
-    documents = factories.DocumentSchemaFactory.build_batch(3, users=["user_sub"])
-    prepare_index(service.index_name, documents)
+    documents = factories.DocumentFactory.build_batch(3, users=["user_sub"])
+    prepare_index(settings.OPENSEARCH_INDEX, documents, service_name=service.name)
     document_to_delete_ids = [doc["id"] for doc in documents[:2]]
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "document_ids": document_to_delete_ids},
+        {"document_ids": document_to_delete_ids},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -69,9 +87,13 @@ def test_api_documents_delete_success(settings):
     for document in documents:
         if document["id"] in document_to_delete_ids:
             with pytest.raises(opensearchpy.exceptions.NotFoundError):
-                opensearch_client_.get(index=service.index_name, id=document["id"])
+                opensearch_client_.get(
+                    index=settings.OPENSEARCH_INDEX, id=document["id"]
+                )
         else:
-            doc = opensearch_client_.get(index=service.index_name, id=document["id"])
+            doc = opensearch_client_.get(
+                index=settings.OPENSEARCH_INDEX, id=document["id"]
+            )
             assert doc["found"]
 
 
@@ -81,14 +103,14 @@ def test_api_documents_delete_no_access(settings):
     setup_oicd_resource_server(responses, settings, sub="user_sub")
     service = factories.ServiceFactory()
     # Create documents where user_sub does NOT have access
-    documents = factories.DocumentSchemaFactory.build_batch(2, users=["other_sub"])
-    prepare_index(service.index_name, documents)
+    documents = factories.DocumentFactory.build_batch(2, users=["other_sub"])
+    prepare_index(settings.OPENSEARCH_INDEX, documents, service_name=service.name)
 
     document_ids = [doc["id"] for doc in documents]
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "document_ids": document_ids},
+        {"document_ids": document_ids},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -102,7 +124,7 @@ def test_api_documents_delete_no_access(settings):
     # Verify documents not deleted
     opensearch_client_ = opensearch_client()
     for doc_id in document_ids:
-        doc = opensearch_client_.get(index=service.index_name, id=doc_id)
+        doc = opensearch_client_.get(index=settings.OPENSEARCH_INDEX, id=doc_id)
         assert doc["found"]
 
 
@@ -113,11 +135,13 @@ def test_api_documents_delete_mixed_access(settings):
 
     service = factories.ServiceFactory()
     # Create documents with different access
-    owned_documents = factories.DocumentSchemaFactory.build_batch(2, users=["user_sub"])
-    other_documents = factories.DocumentSchemaFactory.build_batch(
-        2, users=["other_user"]
+    owned_documents = factories.DocumentFactory.build_batch(2, users=["user_sub"])
+    other_documents = factories.DocumentFactory.build_batch(2, users=["other_user"])
+    prepare_index(
+        settings.OPENSEARCH_INDEX,
+        owned_documents + other_documents,
+        service_name=service.name,
     )
-    prepare_index(service.index_name, owned_documents + other_documents)
 
     owned_document_ids = [doc["id"] for doc in owned_documents]
     other_document_ids = [doc["id"] for doc in other_documents]
@@ -126,7 +150,6 @@ def test_api_documents_delete_mixed_access(settings):
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
         {
-            "service": service.name,
             "document_ids": owned_document_ids
             + other_document_ids
             + non_existing_document_ids,
@@ -145,10 +168,12 @@ def test_api_documents_delete_mixed_access(settings):
     opensearch_client_ = opensearch_client()
     for document_id in owned_document_ids:
         with pytest.raises(opensearchpy.exceptions.NotFoundError):
-            opensearch_client_.get(index=service.index_name, id=document_id)
+            opensearch_client_.get(index=settings.OPENSEARCH_INDEX, id=document_id)
 
     for document_id in other_document_ids:
-        document = opensearch_client_.get(index=service.index_name, id=document_id)
+        document = opensearch_client_.get(
+            index=settings.OPENSEARCH_INDEX, id=document_id
+        )
         assert document["found"]
 
 
@@ -157,10 +182,11 @@ def test_api_documents_delete_missing_document_ids_and_tags(settings):
     """Requests missing both document_ids and tags should return 400."""
     setup_oicd_resource_server(responses, settings, sub="user_sub")
     service = factories.ServiceFactory()
+    prepare_index(settings.OPENSEARCH_INDEX, [], service_name=service.name)
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name},
+        {},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -179,11 +205,10 @@ def test_api_documents_delete_missing_document_ids_and_tags(settings):
 def test_api_documents_delete_empty_document_ids(settings):
     """Requests with empty document_ids and no tags should return 400."""
     setup_oicd_resource_server(responses, settings, sub="user_sub")
-    service = factories.ServiceFactory()
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "document_ids": []},
+        {"document_ids": []},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -202,11 +227,10 @@ def test_api_documents_delete_empty_document_ids(settings):
 def test_api_documents_delete_both_filters_empty(settings):
     """Requests with both document_ids and tags empty should return 400."""
     setup_oicd_resource_server(responses, settings, sub="user_sub")
-    service = factories.ServiceFactory()
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "document_ids": [], "tags": []},
+        {"document_ids": [], "tags": []},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -222,24 +246,6 @@ def test_api_documents_delete_both_filters_empty(settings):
 
 
 @responses.activate
-def test_api_documents_delete_missing_service(settings):
-    """Requests missing the service field should return 400."""
-    setup_oicd_resource_server(responses, settings, sub="user_sub")
-
-    response = APIClient().post(
-        "/api/v1.0/documents/delete/",
-        {"document_ids": ["doc1"]},
-        format="json",
-        HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
-    )
-
-    assert response.status_code == 400
-    assert response.json() == [
-        {"type": "missing", "loc": ["service"], "msg": "Field required"}
-    ]
-
-
-@responses.activate
 def test_api_documents_delete_nonexistent_documents(settings):
     """
     Deleting non-existent documents should not raise an error
@@ -248,11 +254,11 @@ def test_api_documents_delete_nonexistent_documents(settings):
     setup_oicd_resource_server(responses, settings, sub="user_sub")
     service = factories.ServiceFactory()
     # Create index but with no documents
-    prepare_index(service.index_name, [])
+    prepare_index(settings.OPENSEARCH_INDEX, [], service_name=service.name)
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "document_ids": ["non-existent-id"]},
+        {"document_ids": ["non-existent-id"]},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -274,27 +280,29 @@ def test_api_documents_delete_by_single_tag(settings):
     service = factories.ServiceFactory()
 
     document_to_deletes = [
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(
             users=["user_sub"], tags=["delete-tag", "keep-tag-1"]
         ),
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(
             users=["user_sub"], tags=["delete-tag", "keep-tag-2"]
         ),
     ]
     document_to_keep = [
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(
             users=["user_sub"], tags=["keep-tag-1", "keep-tag-2"]
         ),
-        factories.DocumentSchemaFactory.build(users=["user_sub"], tags=["keep-tag-1"]),
-        factories.DocumentSchemaFactory.build(
-            users=["other_user_sub"], tags=["delete-tag"]
-        ),
+        factories.DocumentFactory.build(users=["user_sub"], tags=["keep-tag-1"]),
+        factories.DocumentFactory.build(users=["other_user_sub"], tags=["delete-tag"]),
     ]
-    prepare_index(service.index_name, document_to_deletes + document_to_keep)
+    prepare_index(
+        settings.OPENSEARCH_INDEX,
+        document_to_deletes + document_to_keep,
+        service_name=service.name,
+    )
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "tags": ["delete-tag"]},
+        {"tags": ["delete-tag"]},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -305,10 +313,10 @@ def test_api_documents_delete_by_single_tag(settings):
     opensearch_client_ = opensearch_client()
     for document in document_to_deletes:
         with pytest.raises(opensearchpy.exceptions.NotFoundError):
-            opensearch_client_.get(index=service.index_name, id=document["id"])
+            opensearch_client_.get(index=settings.OPENSEARCH_INDEX, id=document["id"])
 
     for document in document_to_keep:
-        doc = opensearch_client_.get(index=service.index_name, id=document["id"])
+        doc = opensearch_client_.get(index=settings.OPENSEARCH_INDEX, id=document["id"])
         assert doc["found"]
 
 
@@ -319,30 +327,32 @@ def test_api_documents_delete_by_multiple_tags(settings):
     service = factories.ServiceFactory()
 
     document_to_deletes = [
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(
             users=["user_sub"], tags=["delete-tag-1", "keep-tag-1"]
         ),
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(
             users=["user_sub"], tags=["delete-tag-1", "delete-tag-2"]
         ),
-        factories.DocumentSchemaFactory.build(
-            users=["user_sub"], tags=["delete-tag-2"]
-        ),
+        factories.DocumentFactory.build(users=["user_sub"], tags=["delete-tag-2"]),
     ]
     document_to_keep = [
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(
             users=["user_sub"], tags=["keep-tag-1", "keep-tag-2"]
         ),
-        factories.DocumentSchemaFactory.build(users=["user_sub"], tags=["keep-tag-1"]),
-        factories.DocumentSchemaFactory.build(
+        factories.DocumentFactory.build(users=["user_sub"], tags=["keep-tag-1"]),
+        factories.DocumentFactory.build(
             users=["other_user_sub"], tags=["delete-tag-1"]
         ),
     ]
-    prepare_index(service.index_name, document_to_deletes + document_to_keep)
+    prepare_index(
+        settings.OPENSEARCH_INDEX,
+        document_to_deletes + document_to_keep,
+        service_name=service.name,
+    )
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {"service": service.name, "tags": ["delete-tag-1", "delete-tag-2"]},
+        {"tags": ["delete-tag-1", "delete-tag-2"]},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
@@ -353,10 +363,10 @@ def test_api_documents_delete_by_multiple_tags(settings):
     opensearch_client_ = opensearch_client()
     for document in document_to_deletes:
         with pytest.raises(opensearchpy.exceptions.NotFoundError):
-            opensearch_client_.get(index=service.index_name, id=document["id"])
+            opensearch_client_.get(index=settings.OPENSEARCH_INDEX, id=document["id"])
 
     for document in document_to_keep:
-        doc = opensearch_client_.get(index=service.index_name, id=document["id"])
+        doc = opensearch_client_.get(index=settings.OPENSEARCH_INDEX, id=document["id"])
         assert doc["found"]
 
 
@@ -366,29 +376,29 @@ def test_api_documents_delete_by_ids_and_tags(settings):
     setup_oicd_resource_server(responses, settings, sub="user_sub")
     service = factories.ServiceFactory()
 
-    document_delete_by_tag_and_id = factories.DocumentSchemaFactory.build(
+    document_delete_by_tag_and_id = factories.DocumentFactory.build(
         users=["user_sub"], tags=["delete-tag"]
     )
-    document_delete_by_tag_keep_by_id = factories.DocumentSchemaFactory.build(
+    document_delete_by_tag_keep_by_id = factories.DocumentFactory.build(
         users=["user_sub"], tags=["delete-tag"]
     )
-    document_keep_by_tag_delete_by_id = factories.DocumentSchemaFactory.build(
+    document_keep_by_tag_delete_by_id = factories.DocumentFactory.build(
         users=["user_sub"]
     )
 
     prepare_index(
-        service.index_name,
+        settings.OPENSEARCH_INDEX,
         [
             document_delete_by_tag_and_id,
             document_delete_by_tag_keep_by_id,
             document_keep_by_tag_delete_by_id,
         ],
+        service_name=service.name,
     )
 
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
         {
-            "service": service.name,
             "document_ids": [
                 document_delete_by_tag_and_id["id"],
                 document_keep_by_tag_delete_by_id["id"],
@@ -408,10 +418,10 @@ def test_api_documents_delete_by_ids_and_tags(settings):
     opensearch_client_ = opensearch_client()
     with pytest.raises(opensearchpy.exceptions.NotFoundError):
         opensearch_client_.get(
-            index=service.index_name, id=document_delete_by_tag_and_id["id"]
+            index=settings.OPENSEARCH_INDEX, id=document_delete_by_tag_and_id["id"]
         )
 
     doc = opensearch_client_.get(
-        index=service.index_name, id=document_delete_by_tag_keep_by_id["id"]
+        index=settings.OPENSEARCH_INDEX, id=document_delete_by_tag_keep_by_id["id"]
     )
     assert doc["found"]

--- a/src/backend/core/tests/test_api_documents_index_bulk.py
+++ b/src/backend/core/tests/test_api_documents_index_bulk.py
@@ -3,6 +3,7 @@
 import datetime
 from unittest import mock
 
+from django.conf import settings
 from django.utils import timezone
 
 import pytest
@@ -17,7 +18,7 @@ pytestmark = pytest.mark.django_db
 
 def test_api_documents_index_bulk_anonymous():
     """Anonymous requests should not be allowed to index documents in bulk."""
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     response = APIClient().post("/api/v1.0/documents/index/", documents, format="json")
 
@@ -29,7 +30,7 @@ def test_api_documents_index_bulk_anonymous():
 
 def test_api_documents_index_bulk_invalid_token():
     """Requests with invalid tokens should not be allowed to index documents in bulk."""
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     response = APIClient().post(
         "/api/v1.0/documents/index/",
@@ -45,7 +46,7 @@ def test_api_documents_index_bulk_invalid_token():
 def test_api_documents_index_bulk_success():
     """A registered service should be able to index documents in bulk with a valid token."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     response = APIClient().post(
         "/api/v1.0/documents/index/",
@@ -66,10 +67,10 @@ def test_api_documents_index_bulk_ensure_index():
     """A registered service should be created the opensearch index if needed."""
     opensearch_client_ = opensearch.opensearch_client()
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     with pytest.raises(NotFoundError):
-        opensearch_client_.indices.get(index=service.index_name)
+        opensearch_client_.indices.get(index=settings.OPENSEARCH_INDEX)
 
     response = APIClient().post(
         "/api/v1.0/documents/index/",
@@ -86,7 +87,7 @@ def test_api_documents_index_bulk_ensure_index():
     ]
 
     # The index has been rebuilt
-    opensearch_client_.indices.get(index=service.index_name)
+    opensearch_client_.indices.get(index=settings.OPENSEARCH_INDEX)
 
 
 @pytest.mark.parametrize(
@@ -203,7 +204,7 @@ def test_api_documents_index_bulk_invalid_document(
 ):
     """Test bulk document indexing with various invalid fields."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     # Modify the first document with the invalid value for the specified field
     documents[0][field] = invalid_value
@@ -248,7 +249,7 @@ def test_api_documents_index_bulk_invalid_document(
 def test_api_documents_index_bulk_required(field):
     """Test bulk document indexing with a required field missing."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     del documents[0][field]
 
@@ -282,7 +283,7 @@ def test_api_documents_index_bulk_required(field):
 def test_api_documents_index_bulk_default(field, default_value):
     """Test bulk document indexing while removing optional fields that have default values."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     del documents[0][field]
 
@@ -301,7 +302,7 @@ def test_api_documents_index_bulk_default(field, default_value):
     ]
 
     indexed_document = opensearch.opensearch_client().get(
-        index=service.index_name, id=documents[0]["id"]
+        index=settings.OPENSEARCH_INDEX, id=documents[0]["id"]
     )["_source"]
     assert indexed_document[field] == default_value
 
@@ -309,7 +310,7 @@ def test_api_documents_index_bulk_default(field, default_value):
 def test_api_documents_index_bulk_updated_at_before_created_at():
     """Test bulk document indexing with updated_at before created_at."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     documents[0]["updated_at"] = documents[0]["created_at"] - datetime.timedelta(
         seconds=1
@@ -347,7 +348,7 @@ def test_api_documents_index_bulk_updated_at_before_created_at():
 def test_api_documents_index_bulk_datetime_future(field):
     """Test bulk document indexing with datetimes in the future."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     now = timezone.now()
     documents[0][field] = now + datetime.timedelta(seconds=3)
@@ -380,7 +381,7 @@ def test_api_documents_index_bulk_datetime_future(field):
 def test_api_documents_index_empty_content_check():
     """Test bulk document indexing with both empty title & content."""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     documents[0]["content"] = ""
     documents[0]["title"] = ""
@@ -413,7 +414,7 @@ def test_api_documents_index_empty_content_check():
 def test_api_documents_index_opensearch_errors():
     """Test bulk document indexing errors"""
     service = factories.ServiceFactory()
-    documents = factories.DocumentSchemaFactory.build_batch(3)
+    documents = factories.DocumentFactory.build_batch(3)
 
     with mock.patch.object(opensearch.opensearch_client(), "bulk") as mock_bulk:
         mock_bulk.return_value = {

--- a/src/backend/core/tests/test_models_services.py
+++ b/src/backend/core/tests/test_models_services.py
@@ -17,11 +17,10 @@ def test_models_services_name_unique():
         factories.ServiceFactory(name=service.name)
 
 
-def test_models_services_name_slugified(settings):
+def test_models_services_name_slugified():
     """The name field should be slugified."""
     service = factories.ServiceFactory(name="My service name")
     assert service.name == "my-service-name"
-    assert service.index_name == f"{settings.OPENSEARCH_INDEX_PREFIX}-my-service-name"
 
 
 def test_models_services_token_50_characters_exact():

--- a/src/backend/core/tests/test_service_isolation.py
+++ b/src/backend/core/tests/test_service_isolation.py
@@ -1,0 +1,53 @@
+"""Tests for service isolation."""
+
+from django.conf import settings
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories
+from core.services.opensearch import opensearch_client
+
+pytestmark = pytest.mark.django_db
+
+
+class TestIndexServiceIsolation:
+    """Test service field is correctly set during document indexing."""
+
+    def test_index_document_service_field_from_auth_not_payload(self):
+        """Service field in payload is ignored; auth token determines service."""
+        service = factories.ServiceFactory(name="docs-service")
+        document = factories.DocumentFactory.build(service="spoofed-drive")
+
+        response = APIClient().post(
+            "/api/v1.0/documents/index/",
+            document,
+            HTTP_AUTHORIZATION=f"Bearer {service.token:s}",
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        client = opensearch_client()
+        indexed_doc = client.get(index=settings.OPENSEARCH_INDEX, id=document["id"])
+        assert indexed_doc["_source"]["service"] == "docs-service"
+
+    def test_bulk_index_service_field_from_auth_not_payload(self):
+        """Verify service field is correctly set for bulk indexing."""
+        service = factories.ServiceFactory(name="my-docs")
+        documents = factories.DocumentFactory.build_batch(3, service="attempt-spoof")
+
+        response = APIClient().post(
+            "/api/v1.0/documents/index/",
+            documents,
+            HTTP_AUTHORIZATION=f"Bearer {service.token:s}",
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        client = opensearch_client()
+        for doc in documents:
+            indexed_doc = client.get(index=settings.OPENSEARCH_INDEX, id=doc["id"])
+            assert indexed_doc["_source"]["service"] == "my-docs"

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -1,34 +1,6 @@
-"""Tests Service model for find's core app."""
-
-import logging
-from typing import List
+"""Utility functions for find's core app."""
 
 from django.conf import settings as django_settings
-
-from opensearchpy.helpers import bulk
-
-from core.services.indexing import ensure_index_exists, prepare_document_for_indexing
-from core.services.opensearch import opensearch_client
-
-logger = logging.getLogger(__name__)
-
-
-def prepare_index(index_name, documents: List):
-    """Prepare the search index before testing a query on it."""
-    logger.info("Preparing index %s with %d documents", index_name, len(documents))
-
-    ensure_index_exists(index_name)
-    actions = [
-        {
-            "_op_type": "index",
-            "_index": index_name,
-            "_id": document["id"],
-            "_source": prepare_document_for_indexing(document),
-        }
-        for document in documents
-    ]
-    bulk(opensearch_client(), actions)
-    opensearch_client().indices.refresh(index=index_name)
 
 
 def get_language_value(source, language_field):

--- a/src/backend/core/views.py
+++ b/src/backend/core/views.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from django.core.exceptions import SuspiciousOperation
+from django.conf import settings
 
 from lasuite.oidc_resource_server.authentication import ResourceServerAuthentication
 from lasuite.oidc_resource_server.mixins import ResourceServerMixin
@@ -15,7 +15,6 @@ from .authentication import ServiceTokenAuthentication
 from .permissions import IsAuthAuthenticated
 from .services.indexing import (
     ensure_index_exists,
-    get_opensearch_indices,
     prepare_document_for_indexing,
 )
 from .services.opensearch import opensearch_client
@@ -29,8 +28,8 @@ class IndexDocumentView(views.APIView):
     """
     API view for indexing documents in OpenSearch.
         - Handles both single document and bulk document indexing.
-        - The index is dynamically determined based on the service authentication token,
-          ensuring that each service has its own isolated index.
+        - Documents are indexed into a single shared index with a `service` field
+          for scoping, derived from the service authentication token.
     """
 
     authentication_classes = [ServiceTokenAuthentication]
@@ -38,29 +37,13 @@ class IndexDocumentView(views.APIView):
 
     def post(self, request, *args, **kwargs):
         """
-        API view for indexing documents into OpenSearch index of the authenticated service.
+        Index documents into OpenSearch for the authenticated service.
 
-        This view supports both single document indexing and bulk indexing. It handles
-        the following scenarios based on the type of request data:
+        Supports single document and bulk indexing. Documents are stored in a shared
+        index with a `service` field set to the authenticated service's name.
 
-        1. **Single Document Indexing**: If the request contains a single document (as a
-            dictionary), it will be indexed into an OpenSearch index named `find-{auth_token}`.
-            On success, the indexed document is returned with a `201 Created` status. If an
-            error occurs, a `400 Bad Request` response with an error message is returned.
-
-        2. **Bulk Indexing**: If the request contains a list of documents, each document is
-            validated and indexed in bulk. The response includes a detailed status of each
-            document, indicating whether it was successfully indexed or if an error occurred.
-            The HTTP status code for the bulk indexing operation is `207 Multi-Status`, and the
-            response body contains information about the success or failure of each individual
-            document.
-
-        Methods:
-        -------
-        post(request, *args, **kwargs):
-            Handles POST requests to index either a single document or a list of documents.
-            - **Single Document**: Expects a dictionary representing a document.
-            - **Bulk Indexing**: Expects a list of dictionaries, each representing a document.
+        1. **Single Document**: Dictionary input returns `201 Created` with document ID.
+        2. **Bulk Indexing**: List input returns `207 Multi-Status` with per-document results.
 
         Request Data:
         -------------
@@ -84,7 +67,7 @@ class IndexDocumentView(views.APIView):
             - Returns a list of results for all documents, with details of success and indexing
               errors.
         """
-        index_name = request.auth.index_name
+        index_name = settings.OPENSEARCH_INDEX
         opensearch_client_ = opensearch_client()
 
         if isinstance(request.data, list):
@@ -107,7 +90,8 @@ class IndexDocumentView(views.APIView):
                 - 400 Bad Request: Returns an error message if the document is invalid.
         """
         document_dict = prepare_document_for_indexing(
-            schemas.DocumentSchema(**request.data).model_dump()
+            schemas.Document(**request.data).model_dump(),
+            service_name=request.auth.name,
         )
         _id = document_dict.pop("id")
         logger.info(
@@ -148,7 +132,7 @@ class IndexDocumentView(views.APIView):
 
         for i, document_data in enumerate(request.data):
             try:
-                document = schemas.DocumentSchema(**document_data)
+                document = schemas.Document(**document_data)
             except PydanticValidationError as excpt:
                 errors = [
                     {key: error[key] for key in ("msg", "type", "loc")}
@@ -157,7 +141,10 @@ class IndexDocumentView(views.APIView):
                 results.append({"index": i, "status": "error", "errors": errors})
                 has_errors = True
             else:
-                document_dict = prepare_document_for_indexing(document.model_dump())
+                document_dict = prepare_document_for_indexing(
+                    document.model_dump(),
+                    service_name=request.auth.name,
+                )
                 logger.info(
                     "Indexing document %s on index %s",
                     get_language_value(document_dict, "title"),
@@ -224,28 +211,17 @@ class DeleteDocumentsView(ResourceServerMixin, views.APIView):
                 because the user is not authorized to delete it or because a tag filter was used.
             - 400 Bad Request: If parameters are invalid or missing.
         """
-        params = schemas.DeleteDocumentsSchema(**request.data)
-        try:
-            index_name = get_opensearch_indices(
-                self._get_service_provider_audience(), services=[params.service]
-            )[0]
-        except SuspiciousOperation as e:
-            logger.error(e)
-            return Response(
-                {"detail": "Invalid request."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        params = schemas.DeleteDocuments(**request.data)
 
         logger.info(
-            "Deleting documents from index %s with filters: document_ids=%s, tags=%s",
-            index_name,
+            "Deleting documents with filters: document_ids=%s, tags=%s",
             params.document_ids,
             params.tags,
         )
 
         client = opensearch_client()
         deletable_matches = client.search(
-            index=index_name,
+            index=settings.OPENSEARCH_INDEX,
             body={
                 "query": self._build_query(
                     self.request.user.sub,
@@ -258,7 +234,7 @@ class DeleteDocumentsView(ResourceServerMixin, views.APIView):
 
         if deletable_ids:
             response = client.delete_by_query(
-                index=index_name,
+                index=settings.OPENSEARCH_INDEX,
                 body={"query": {"ids": {"values": deletable_ids}}},
             )
             nb_deleted = response.get("deleted", 0)
@@ -289,7 +265,9 @@ class DeleteDocumentsView(ResourceServerMixin, views.APIView):
         Returns:
             Deletion OpenSearch query.
         """
-        filters = [{"term": {"users": user_sub}}]
+        filters = [
+            {"term": {"users": user_sub}},
+        ]
         if document_ids:
             filters.append({"ids": {"values": document_ids}})
         if tags:
@@ -353,34 +331,23 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
             - 400 Bad Request: If the query parameter 'q' is not provided or invalid.
         """
         # Get list of groups related to the user from SCIM provider (consider caching result)
-        audience = self._get_service_provider_audience()
         user_sub = self.request.user.sub
         groups = []
 
         try:
-            params = schemas.SearchQueryParametersSchema(**request.data)
+            params = schemas.SearchQueryParameters(**request.data)
         except PydanticValidationError as excpt:
             errors = {error["loc"][0]: error["msg"] for error in excpt.errors()}
             logger.error("Validation error: %s", errors)
             raise excpt
 
-        # Get index list for search query
-        try:
-            search_indices = get_opensearch_indices(audience, services=params.services)
-        except SuspiciousOperation as e:
-            logger.error(e, exc_info=True)
-            return Response(
-                {"detail": "Invalid request."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        logger.info("Search '%s' on indices %s", params.q, search_indices)
+        logger.info("Search '%s' on index %s", params.q, settings.OPENSEARCH_INDEX)
         result = search(
             q=params.q,
             nb_results=params.nb_results,
             order_by=params.order_by,
             order_direction=params.order_direction,
-            search_indices=search_indices,
+            search_indices=[settings.OPENSEARCH_INDEX],
             reach=params.reach,
             visited=params.visited,
             user_sub=user_sub,

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 
 from faker import Faker
+from opensearchpy.exceptions import NotFoundError
 from opensearchpy.helpers import bulk
 
 from core import enums, factories
@@ -144,40 +145,35 @@ def create_demo(stdout):
     Create a database with demo data for developers to work in a realistic environment.
     """
     opensearch_client_ = opensearch_client()
-    opensearch_client_.indices.delete(index="*")
+    try:
+        opensearch_client_.indices.delete(index="*")
+    except NotFoundError:
+        pass
 
     with Timeit(stdout, "Creating services"):
         services = factories.ServiceFactory.create_batch(
             defaults.NB_OBJECTS["services"]
         )
 
-        for service in services:
-            ensure_index_exists(service.name)
-            opensearch_client_.indices.refresh(index=service.name)
+        ensure_index_exists(settings.OPENSEARCH_INDEX)
 
     with Timeit(stdout, "Creating documents"):
         actions = BulkIndexing(stdout)
         for _ in range(defaults.NB_OBJECTS["documents"]):
             service = random.choice(services)
             document = generate_document()
-            actions.push(service.name, uuid4(), document)
+            document["service"] = service.name
+            actions.push(settings.OPENSEARCH_INDEX, uuid4(), document)
         actions.flush()
 
     with Timeit(stdout, "Creating dev services"):
         for conf in defaults.DEV_SERVICES:
             service = factories.ServiceFactory(**conf)
-            ensure_index_exists(service.name)
-            opensearch_client_.indices.refresh(index=service.name)
 
     # Check and report on indexed documents
-    total_indexed = 0
-    for service in services:
-        opensearch_client_.indices.refresh(index=service.name)
-        indexed = opensearch_client_.count(index=service.name)["count"]
-        stdout.write(f"  - {service.name:s}: {indexed:d} documents")
-        total_indexed += indexed
-
-    stdout.write(f"  TOTAL: {total_indexed:d} documents")
+    opensearch_client_.indices.refresh(index=settings.OPENSEARCH_INDEX)
+    indexed = opensearch_client_.count(index=settings.OPENSEARCH_INDEX)["count"]
+    stdout.write(f"  TOTAL: {indexed:d} documents")
 
 
 class Command(BaseCommand):

--- a/src/backend/demo/tests/test_commands_create_demo.py
+++ b/src/backend/demo/tests/test_commands_create_demo.py
@@ -22,12 +22,12 @@ TEST_NB_OBJECTS = {
 
 @override_settings(DEBUG=True)
 @mock.patch.dict(defaults.NB_OBJECTS, TEST_NB_OBJECTS)
-def test_commands_create_demo():
+def test_commands_create_demo(settings):
     """The create_demo management command should create objects as expected."""
     call_command("create_demo")
 
     assert models.Service.objects.exclude(name="docs").count() == 4
-    assert opensearch_client().count()["count"] == 4
+    assert opensearch_client().count(index=settings.OPENSEARCH_INDEX)["count"] == 4
 
     docs = models.Service.objects.get(name="docs")
     assert docs.client_id == "impress"

--- a/src/backend/find/settings.py
+++ b/src/backend/find/settings.py
@@ -252,8 +252,8 @@ class Base(Configuration):
     OPENSEARCH_USE_SSL = values.BooleanValue(
         default=True, environ_name="OPENSEARCH_USE_SSL", environ_prefix=None
     )
-    OPENSEARCH_INDEX_PREFIX = values.Value(
-        default="find", environ_name="OPENSEARCH_INDEX_PREFIX", environ_prefix=None
+    OPENSEARCH_INDEX = values.Value(
+        default="find", environ_name="OPENSEARCH_INDEX", environ_prefix=None
     )
 
     SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
## Summary

- Consolidate multi-index architecture (one index per service) into a single unified OpenSearch index with a `service` field for scoping
- Services can only modify their own documents (enforced via query-level service filter)
- Users can search across multiple services based on their access rights

## Changes

### Core Architecture
- **Single index**: All services now write to `OPENSEARCH_INDEX` (default: `find`) instead of `{prefix}-{service_name}`
- **Service field**: Added `service` keyword field to OpenSearch mapping, populated from authenticated token
- **Query scoping**: Delete and search operations include `{"term": {"service": service_name}}` filter

### Security
- Service field derived from `request.auth.name` (authenticated token), never from client payload
- `DocumentSchema` does not include `service` field - clients cannot inject it
- Cross-service access controlled via `Service.services` relationship

### Files Changed
- `opensearch_configuration.py` - Added `service` keyword field to MAPPINGS
- `settings.py` - Renamed `OPENSEARCH_INDEX_PREFIX` → `OPENSEARCH_INDEX`
- `indexing.py` - Single index, service field population from auth token
- `search.py` - Service filter in queries when services param provided
- `views.py` - Service scoping in index/delete operations
- `create_demo.py` - Fixed to use unified index pattern
- `values.yaml` - Helm chart updated with new env var
- `setup-indexer.md` - Documentation updated

### Tests
- Added `test_service_isolation.py` with 7 test methods covering:
  - Index spoofing prevention (service from auth, not payload)
  - Delete scoping (only own service's documents)
  - Search filtering (service filter applied correctly)
  - Cross-service search (via Service.services relationship)
  - Unauthorized service rejection

## Migration Notes

- **No automatic migration**: Services should re-push their data after upgrade
- **Old indices**: Operators should manually delete old `{prefix}-{service}` indices
- **Environment variable**: Update `OPENSEARCH_INDEX_PREFIX` → `OPENSEARCH_INDEX` in deployments