### PR TITLE
Add content_hash field for future document deduplication/caching/indexing

### DIFF
--- a/src/backend/core/services/indexing.py
+++ b/src/backend/core/services/indexing.py
@@ -1,5 +1,6 @@
 """OpenSearch indexing utilities."""
 
+import hashlib
 import logging
 
 from django.conf import settings
@@ -45,10 +46,19 @@ def ensure_index_exists(index_name):
         )
 
 
+def compute_content_hash(title: str, content: str) -> str:
+    """Compute SHA-256 hash of title and content for change detection."""
+    h = hashlib.sha256()
+    h.update(title.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(content.encode("utf-8"))
+    return h.hexdigest()
+
+
 def prepare_document_for_indexing(document):
     """Prepare document for indexing using nested language structure"""
     language_code = detect_language_code(f"{document['title']} {document['content']}")
-    return {
+    result = {
         "id": document["id"],
         f"title.{language_code}": document["title"],
         f"content.{language_code}": document["content"],
@@ -63,7 +73,9 @@ def prepare_document_for_indexing(document):
         "reach": document["reach"],
         "tags": document.get("tags", []),
         "is_active": document["is_active"],
+        "content_hash": compute_content_hash(document["title"], document["content"]),
     }
+    return result
 
 
 def detect_language_code(text):

--- a/src/backend/core/services/opensearch_configuration.py
+++ b/src/backend/core/services/opensearch_configuration.py
@@ -254,6 +254,7 @@ MAPPINGS = {
                 }
             },
         },
+        "content_hash": {"type": "keyword"},
         "depth": {"type": "integer"},
         "path": {
             "type": "keyword",

--- a/src/backend/core/tests/test_api_documents_index_bulk.py
+++ b/src/backend/core/tests/test_api_documents_index_bulk.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIClient
 
 from core import factories
 from core.services import opensearch
+from core.services.indexing import compute_content_hash
 
 pytestmark = pytest.mark.django_db
 
@@ -57,6 +58,14 @@ def test_api_documents_index_bulk_success():
     assert response.status_code == 201
     responses = response.json()
     assert [d["status"] for d in responses] == ["success"] * 3
+
+    opensearch.opensearch_client().indices.refresh(index=service.index_name)
+    indexed = opensearch.opensearch_client().get(
+        index=service.index_name, id=responses[0]["_id"]
+    )["_source"]
+    assert indexed["content_hash"] == compute_content_hash(
+        documents[0]["title"].strip().lower(), documents[0]["content"]
+    )
 
 
 def test_api_documents_index_bulk_ensure_index():

--- a/src/backend/core/tests/test_content_hash.py
+++ b/src/backend/core/tests/test_content_hash.py
@@ -1,0 +1,56 @@
+"""Tests for compute_content_hash function."""
+
+from core.services.indexing import compute_content_hash
+
+
+def test_compute_content_hash_deterministic():
+    """Same input should always produce the same hash."""
+    title = "Test Document"
+    content = "This is test content"
+
+    hash1 = compute_content_hash(title, content)
+    hash2 = compute_content_hash(title, content)
+
+    assert hash1 == hash2
+    assert len(hash1) == 64  # SHA-256 hex digest is 64 characters
+
+
+def test_compute_content_hash_different_inputs():
+    """Different inputs should produce different hashes."""
+    hash1 = compute_content_hash("Title 1", "Content 1")
+    hash2 = compute_content_hash("Title 2", "Content 2")
+    hash3 = compute_content_hash("Title 1", "Content 2")
+
+    assert hash1 != hash2
+    assert hash1 != hash3
+    assert hash2 != hash3
+
+
+def test_compute_content_hash_empty_title():
+    """Empty title with content should produce a valid hash."""
+    title = ""
+    content = "This is test content"
+
+    hash_result = compute_content_hash(title, content)
+
+    assert len(hash_result) == 64
+    assert hash_result == compute_content_hash("", content)
+
+
+def test_compute_content_hash_empty_content():
+    """Title with empty content should produce a valid hash."""
+    title = "Test Document"
+    content = ""
+
+    hash_result = compute_content_hash(title, content)
+
+    assert len(hash_result) == 64
+    assert hash_result == compute_content_hash(title, "")
+
+
+def test_compute_content_hash_no_collision():
+    """Null separator should prevent collisions between different title/content combinations."""
+    hash1 = compute_content_hash("hello", "world")
+    hash2 = compute_content_hash("hellow", "orld")
+
+    assert hash1 != hash2


### PR DESCRIPTION
## Summary

- Add `content_hash` field to OpenSearch mappings for document deduplication
- Compute hash from title + content during indexing
- Add comprehensive tests for hash computation and indexing

## Changes

| File | Description |
|------|-------------|
| `indexing.py` | Add content_hash computation during document indexing |
| `opensearch_configuration.py` | Add content_hash field to mappings |
| `test_content_hash.py` | Tests for hash computation and indexing |