### PR TITLE
Strengthen test assertions by explicitness

### DIFF
--- a/src/backend/core/tests/test_admin_selftest.py
+++ b/src/backend/core/tests/test_admin_selftest.py
@@ -35,7 +35,7 @@ def test_selftest_requires_authentication(client):
 
     # Should redirect to login
     assert response.status_code == 302
-    assert "/admin/login/" in response.url
+    assert response.url == "/admin/login/?next=/admin/selftest/"
 
 
 def test_selftest_requires_staff_permission(client):
@@ -53,6 +53,7 @@ def test_selftest_requires_staff_permission(client):
 
     # Regular users should be redirected
     assert response.status_code == 302
+    assert response.url == "/admin/login/?next=/admin/selftest/"
 
 
 def test_selftest_accessible_by_admin(client):

--- a/src/backend/core/tests/test_api_documents_delete.py
+++ b/src/backend/core/tests/test_api_documents_delete.py
@@ -23,6 +23,9 @@ def test_api_documents_delete_anonymous():
     )
 
     assert response.status_code == 401
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
 
 
 @responses.activate
@@ -38,7 +41,7 @@ def test_api_documents_delete_wrong_service_name(settings):
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid request."
+    assert response.json() == {"detail": "Invalid request."}
 
 
 @responses.activate
@@ -60,8 +63,7 @@ def test_api_documents_delete_success(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 2
-    assert response.json()["undeleted-document-ids"] == []
+    assert response.json() == {"nb-deleted-documents": 2, "undeleted-document-ids": []}
 
     opensearch_client_ = opensearch_client()
     for document in documents:
@@ -92,8 +94,10 @@ def test_api_documents_delete_no_access(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 0
-    assert set(response.json()["undeleted-document-ids"]) == set(document_ids)
+    assert response.json() == {
+        "nb-deleted-documents": 0,
+        "undeleted-document-ids": document_ids,
+    }
 
     # Verify documents not deleted
     opensearch_client_ = opensearch_client()
@@ -132,10 +136,10 @@ def test_api_documents_delete_mixed_access(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 2
-    assert set(response.json()["undeleted-document-ids"]) == set(
-        other_document_ids + non_existing_document_ids
-    )
+    assert response.json() == {
+        "nb-deleted-documents": 2,
+        "undeleted-document-ids": other_document_ids + non_existing_document_ids,
+    }
 
     # Verify only owned documents are deleted
     opensearch_client_ = opensearch_client()
@@ -149,28 +153,34 @@ def test_api_documents_delete_mixed_access(settings):
 
 
 @responses.activate
-def test_api_documents_delete_invalid_params(settings):
-    """Requests with invalid parameters should return 400 Bad Request."""
+def test_api_documents_delete_missing_document_ids_and_tags(settings):
+    """Requests missing both document_ids and tags should return 400."""
     setup_oicd_resource_server(responses, settings, sub="user_sub")
     service = factories.ServiceFactory()
 
-    # Missing both document_ids and tags
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
-        {
-            "service": service.name,
-        },
+        {"service": service.name},
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}",
     )
 
     assert response.status_code == 400
-    assert (
-        response.json()[0]["msg"]
-        == "Value error, At least one of 'document_ids' or 'tags' must be provided"
-    )
+    assert response.json() == [
+        {
+            "type": "value_error",
+            "loc": [],
+            "msg": "Value error, At least one of 'document_ids' or 'tags' must be provided",
+        }
+    ]
 
-    # Empty document_ids and no tags
+
+@responses.activate
+def test_api_documents_delete_empty_document_ids(settings):
+    """Requests with empty document_ids and no tags should return 400."""
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+    service = factories.ServiceFactory()
+
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
         {"service": service.name, "document_ids": []},
@@ -179,12 +189,21 @@ def test_api_documents_delete_invalid_params(settings):
     )
 
     assert response.status_code == 400
-    assert (
-        response.json()[0]["msg"]
-        == "Value error, At least one of 'document_ids' or 'tags' must be provided"
-    )
+    assert response.json() == [
+        {
+            "type": "value_error",
+            "loc": [],
+            "msg": "Value error, At least one of 'document_ids' or 'tags' must be provided",
+        }
+    ]
 
-    # Both empty
+
+@responses.activate
+def test_api_documents_delete_both_filters_empty(settings):
+    """Requests with both document_ids and tags empty should return 400."""
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+    service = factories.ServiceFactory()
+
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
         {"service": service.name, "document_ids": [], "tags": []},
@@ -193,12 +212,20 @@ def test_api_documents_delete_invalid_params(settings):
     )
 
     assert response.status_code == 400
-    assert (
-        response.json()[0]["msg"]
-        == "Value error, At least one of 'document_ids' or 'tags' must be provided"
-    )
+    assert response.json() == [
+        {
+            "type": "value_error",
+            "loc": [],
+            "msg": "Value error, At least one of 'document_ids' or 'tags' must be provided",
+        }
+    ]
 
-    # Missing service
+
+@responses.activate
+def test_api_documents_delete_missing_service(settings):
+    """Requests missing the service field should return 400."""
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+
     response = APIClient().post(
         "/api/v1.0/documents/delete/",
         {"document_ids": ["doc1"]},
@@ -207,6 +234,9 @@ def test_api_documents_delete_invalid_params(settings):
     )
 
     assert response.status_code == 400
+    assert response.json() == [
+        {"type": "missing", "loc": ["service"], "msg": "Field required"}
+    ]
 
 
 @responses.activate
@@ -228,8 +258,10 @@ def test_api_documents_delete_nonexistent_documents(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 0
-    assert response.json()["undeleted-document-ids"] == ["non-existent-id"]
+    assert response.json() == {
+        "nb-deleted-documents": 0,
+        "undeleted-document-ids": ["non-existent-id"],
+    }
 
 
 @responses.activate
@@ -265,8 +297,7 @@ def test_api_documents_delete_by_single_tag(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 2
-    assert response.json()["undeleted-document-ids"] == []
+    assert response.json() == {"nb-deleted-documents": 2, "undeleted-document-ids": []}
 
     opensearch_client_ = opensearch_client()
     for document in document_to_deletes:
@@ -314,8 +345,7 @@ def test_api_documents_delete_by_multiple_tags(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 3
-    assert response.json()["undeleted-document-ids"] == []
+    assert response.json() == {"nb-deleted-documents": 3, "undeleted-document-ids": []}
 
     opensearch_client_ = opensearch_client()
     for document in document_to_deletes:
@@ -367,10 +397,10 @@ def test_api_documents_delete_by_ids_and_tags(settings):
     )
 
     assert response.status_code == 200
-    assert response.json()["nb-deleted-documents"] == 1
-    assert response.json()["undeleted-document-ids"] == [
-        document_keep_by_tag_delete_by_id["id"]
-    ]
+    assert response.json() == {
+        "nb-deleted-documents": 1,
+        "undeleted-document-ids": [document_keep_by_tag_delete_by_id["id"]],
+    }
 
     opensearch_client_ = opensearch_client()
     with pytest.raises(opensearchpy.exceptions.NotFoundError):

--- a/src/backend/core/tests/test_api_documents_index_bulk.py
+++ b/src/backend/core/tests/test_api_documents_index_bulk.py
@@ -55,8 +55,11 @@ def test_api_documents_index_bulk_success():
     )
 
     assert response.status_code == 201
-    responses = response.json()
-    assert [d["status"] for d in responses] == ["success"] * 3
+    assert response.json() == [
+        {"index": 0, "_id": documents[0]["id"], "status": "success"},
+        {"index": 1, "_id": documents[1]["id"], "status": "success"},
+        {"index": 2, "_id": documents[2]["id"], "status": "success"},
+    ]
 
 
 def test_api_documents_index_bulk_ensure_index():
@@ -76,9 +79,11 @@ def test_api_documents_index_bulk_ensure_index():
     )
 
     assert response.status_code == 201
-    responses = response.json()
-    assert len(responses) == 3
-    assert [d["status"] for d in responses] == ["success"] * 3
+    assert response.json() == [
+        {"index": 0, "_id": documents[0]["id"], "status": "success"},
+        {"index": 1, "_id": documents[1]["id"], "status": "success"},
+        {"index": 2, "_id": documents[2]["id"], "status": "success"},
+    ]
 
     # The index has been rebuilt
     opensearch_client_.indices.get(index=service.index_name)
@@ -214,13 +219,18 @@ def test_api_documents_index_bulk_invalid_document(
     )
 
     assert response.status_code == 400
-    responses = response.json()
-    assert [d["status"] for d in responses] == ["error", "valid", "valid"]
 
-    assert responses[0]["status"] == "error"
-    assert len(responses[0]["errors"]) == 1
-    assert responses[0]["errors"][0]["msg"] == error_message
-    assert responses[0]["errors"][0]["type"] == error_type
+    # When invalid_value is a list, the error loc includes the element index
+    expected_loc = [field, 0] if isinstance(invalid_value, list) else [field]
+    assert response.json() == [
+        {
+            "index": 0,
+            "status": "error",
+            "errors": [{"msg": error_message, "type": error_type, "loc": expected_loc}],
+        },
+        {"index": 1, "_id": documents[1]["id"], "status": "valid"},
+        {"index": 2, "_id": documents[2]["id"], "status": "valid"},
+    ]
 
 
 @pytest.mark.parametrize(
@@ -253,13 +263,15 @@ def test_api_documents_index_bulk_required(field):
     )
 
     assert response.status_code == 400
-    responses = response.json()
-    assert [d["status"] for d in responses] == ["error", "valid", "valid"]
-
-    assert responses[0]["status"] == "error"
-    assert len(responses[0]["errors"]) == 1
-    assert responses[0]["errors"][0]["msg"] == "Field required"
-    assert responses[0]["errors"][0]["type"] == "missing"
+    assert response.json() == [
+        {
+            "index": 0,
+            "status": "error",
+            "errors": [{"msg": "Field required", "type": "missing", "loc": [field]}],
+        },
+        {"index": 1, "_id": documents[1]["id"], "status": "valid"},
+        {"index": 2, "_id": documents[2]["id"], "status": "valid"},
+    ]
 
 
 @pytest.mark.parametrize(
@@ -285,11 +297,14 @@ def test_api_documents_index_bulk_default(field, default_value):
     )
 
     assert response.status_code == 201
-    responses = response.json()
-    assert [d["status"] for d in responses] == ["success"] * 3
+    assert response.json() == [
+        {"index": 0, "_id": documents[0]["id"], "status": "success"},
+        {"index": 1, "_id": documents[1]["id"], "status": "success"},
+        {"index": 2, "_id": documents[2]["id"], "status": "success"},
+    ]
 
     indexed_document = opensearch.opensearch_client().get(
-        index=service.index_name, id=responses[0]["_id"]
+        index=service.index_name, id=documents[0]["id"]
     )["_source"]
     assert indexed_document[field] == default_value
 
@@ -311,17 +326,21 @@ def test_api_documents_index_bulk_updated_at_before_created_at():
     )
 
     assert response.status_code == 400
-    responses = response.json()
-
-    assert [d["status"] for d in responses] == ["error", "valid", "valid"]
-
-    assert responses[0]["status"] == "error"
-    assert len(responses[0]["errors"]) == 1
-    assert (
-        responses[0]["errors"][0]["msg"]
-        == "Value error, updated_at must be later than created_at"
-    )
-    assert responses[0]["errors"][0]["type"] == "value_error"
+    assert response.json() == [
+        {
+            "index": 0,
+            "status": "error",
+            "errors": [
+                {
+                    "msg": "Value error, updated_at must be later than created_at",
+                    "type": "value_error",
+                    "loc": [],
+                }
+            ],
+        },
+        {"index": 1, "_id": documents[1]["id"], "status": "valid"},
+        {"index": 2, "_id": documents[2]["id"], "status": "valid"},
+    ]
 
 
 @pytest.mark.parametrize(
@@ -344,16 +363,21 @@ def test_api_documents_index_bulk_datetime_future(field):
     )
 
     assert response.status_code == 400
-    responses = response.json()
-    assert [d["status"] for d in responses] == ["error", "valid", "valid"]
-
-    assert responses[0]["status"] == "error"
-    assert len(responses[0]["errors"]) == 1
-    assert (
-        responses[0]["errors"][0]["msg"]
-        == f"Value error, {field:s} must be earlier than now"
-    )
-    assert responses[0]["errors"][0]["type"] == "value_error"
+    assert response.json() == [
+        {
+            "index": 0,
+            "status": "error",
+            "errors": [
+                {
+                    "msg": f"Value error, {field:s} must be earlier than now",
+                    "type": "value_error",
+                    "loc": [field],
+                }
+            ],
+        },
+        {"index": 1, "_id": documents[1]["id"], "status": "valid"},
+        {"index": 2, "_id": documents[2]["id"], "status": "valid"},
+    ]
 
 
 def test_api_documents_index_empty_content_check():
@@ -372,16 +396,21 @@ def test_api_documents_index_empty_content_check():
     )
 
     assert response.status_code == 400
-    responses = response.json()
-    assert [d["status"] for d in responses] == ["error", "valid", "valid"]
-
-    assert responses[0]["status"] == "error"
-    assert len(responses[0]["errors"]) == 1
-    assert (
-        responses[0]["errors"][0]["msg"]
-        == "Value error, Either title or content should have at least 1 character"
-    )
-    assert responses[0]["errors"][0]["type"] == "value_error"
+    assert response.json() == [
+        {
+            "index": 0,
+            "status": "error",
+            "errors": [
+                {
+                    "msg": "Value error, Either title or content should have at least 1 character",
+                    "type": "value_error",
+                    "loc": [],
+                }
+            ],
+        },
+        {"index": 1, "_id": documents[1]["id"], "status": "valid"},
+        {"index": 2, "_id": documents[2]["id"], "status": "valid"},
+    ]
 
 
 def test_api_documents_index_opensearch_errors():
@@ -410,8 +439,7 @@ def test_api_documents_index_opensearch_errors():
         )
 
     assert response.status_code == 201
-    responses = response.json()
-    assert responses == [
+    assert response.json() == [
         {
             "_id": documents[0]["id"],
             "index": 0,


### PR DESCRIPTION
- Replace partial/lazy test assertions with explicit `assert response.json() == {...}` checks
- Split multi-scenario tests into focused single-scenario tests