### PR TITLE
Normalize HTTP response formats

### DIFF
--- a/src/backend/core/handlers.py
+++ b/src/backend/core/handlers.py
@@ -8,7 +8,16 @@ from django_bolt.exceptions import HTTPException
 
 from .bolt_auth import OIDCAuthentication, ServiceTokenAuthentication
 from .query.builder import combine_with_system_scope
-from .schemas import Document, SearchParams, SearchQuerySchema, SortClause, parse_where_clause
+from .schemas import (
+    Document,
+    IndexResponse,
+    SearchParams,
+    SearchQuerySchema,
+    SearchResponse,
+    SearchResultDocument,
+    SortClause,
+    parse_where_clause,
+)
 from .services import opensearch
 from .services.indexing import prepare_document_for_indexing
 from .services.search import search
@@ -38,7 +47,7 @@ async def _require_service_context(request: dict[str, Any]) -> dict[str, Any]:
 
 
 @api.post("/documents/search")
-async def search_documents(request: dict[str, Any], search_query: SearchQuerySchema) -> list[dict[str, Any]]:
+async def search_documents(request: dict[str, Any], search_query: SearchQuerySchema) -> SearchResponse:
     user = await _require_oidc_user(request)
     user_sub = user.sub
     service = getattr(user, "token_audience", None)
@@ -60,9 +69,20 @@ async def search_documents(request: dict[str, Any], search_query: SearchQuerySch
         limit=search_query.limit,
     )
 
-    result = search(search_params, [settings.OPENSEARCH_INDEX])["hits"]["hits"]
+    result = search(search_params, [settings.OPENSEARCH_INDEX])
+    hits = result["hits"]["hits"]
+    total = result["hits"]["total"]["value"]
 
-    return result
+    data = [
+        SearchResultDocument(
+            id=hit["_id"],
+            **hit["_source"],
+            **hit.get("fields", {}),
+        )
+        for hit in hits
+    ]
+
+    return SearchResponse(data=data, total=total, limit=search_query.limit or 50)
 
 
 @api.delete("/documents/{document_id}", status_code=204)
@@ -81,7 +101,7 @@ async def delete_document(request: dict[str, Any], document_id: str) -> None:
 
 
 @api.post("/documents/index", status_code=201)
-async def index_document(request: dict[str, Any], document: Document) -> dict[str, str]:
+async def index_document(request: dict[str, Any], document: Document) -> IndexResponse:
     context = await _require_service_context(request)
     index_name = settings.OPENSEARCH_INDEX
     opensearch_client_ = opensearch.opensearch_client()
@@ -105,12 +125,12 @@ async def index_document(request: dict[str, Any], document: Document) -> dict[st
         },
         service_name=context.get("service_name"),
     )
-    _id = document_dict.pop("id")
+    doc_id = document_dict.pop("id")
 
     opensearch_client_.index(
         index=index_name,
         body=document_dict,
-        id=_id,
+        id=doc_id,
     )
 
-    return {"_id": str(_id)}
+    return IndexResponse(id=str(doc_id))

--- a/src/backend/core/schemas.py
+++ b/src/backend/core/schemas.py
@@ -164,6 +164,32 @@ class SearchParams(Struct):
     limit: int | None = 50
 
 
+class IndexResponse(Struct):
+    id: str
+
+
+class SearchResultDocument(Struct):
+    id: str
+    title: str
+    content: str
+    size: int
+    depth: int
+    path: str
+    numchild: int
+    created_at: str
+    updated_at: str
+    reach: str | None = None
+    tags: list[str] = []
+    number_of_users: list[int] | None = None
+    number_of_groups: list[int] | None = None
+
+
+class SearchResponse(Struct):
+    data: list[SearchResultDocument]
+    total: int
+    limit: int
+
+
 # All allowed field names for validation
 _ALLOWED_FIELDS: frozenset[str] = frozenset(
     [

--- a/src/backend/core/tests/test_handlers_delete.py
+++ b/src/backend/core/tests/test_handlers_delete.py
@@ -18,7 +18,6 @@ class TestDeleteDocumentHandler:
         mock_service_context: dict,
         bolt_client: TestClient,
     ) -> None:
-        # First, index a document so we can delete it
         client = opensearch_client()
         client.index(
             index=settings.OPENSEARCH_INDEX,
@@ -75,7 +74,6 @@ class TestDeleteDocumentHandler:
     ) -> None:
         doc_id = "550e8400-e29b-41d4-a716-446655440000"
 
-        # First, index a document so we can delete it
         client = opensearch_client()
         client.index(
             index=settings.OPENSEARCH_INDEX,

--- a/src/backend/core/tests/test_handlers_index.py
+++ b/src/backend/core/tests/test_handlers_index.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 import pytest
 from django_bolt.testing import TestClient
 
-from core import factories, models
+from core import factories
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -47,7 +47,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     def test_index_missing_auth_returns_401(
         self,
@@ -278,7 +278,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     def test_index_future_created_at_rejected(
         self,
@@ -410,7 +410,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     def test_index_invalid_group_format_rejected(
         self,
@@ -455,7 +455,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     @pytest.mark.vcr
     def test_index_service_name_from_auth(
@@ -471,7 +471,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     @pytest.mark.vcr
     def test_index_with_reach_field(
@@ -489,7 +489,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     @pytest.mark.vcr
     def test_index_with_tags(
@@ -507,7 +507,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     @pytest.mark.vcr
     def test_index_with_users_and_groups(
@@ -526,7 +526,7 @@ class TestIndexDocumentView:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": valid_document_payload["id"]}
+        assert response.json() == {"id": valid_document_payload["id"]}
 
     def test_index_title_too_long_rejected(
         self,
@@ -621,4 +621,4 @@ class TestServiceIsolation:
         )
 
         assert response.status_code == 201
-        assert response.json() == {"_id": document["id"]}
+        assert response.json() == {"id": document["id"]}

--- a/src/backend/core/tests/test_handlers_search.py
+++ b/src/backend/core/tests/test_handlers_search.py
@@ -22,7 +22,7 @@ class TestSearchDocumentsHandler:
         )
 
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == {"data": [], "total": 0, "limit": 10}
 
     @pytest.mark.vcr
     def test_search_with_where_clause_returns_200(
@@ -43,7 +43,7 @@ class TestSearchDocumentsHandler:
         )
 
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == {"data": [], "total": 0, "limit": 10}
 
     @pytest.mark.vcr
     def test_search_with_sort_and_limit_returns_200(
@@ -62,7 +62,7 @@ class TestSearchDocumentsHandler:
         )
 
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == {"data": [], "total": 0, "limit": 5}
 
     def test_search_missing_auth_returns_401(self, bolt_client: TestClient) -> None:
         response = bolt_client.post(


### PR DESCRIPTION
## Summary
- Normalize API responses to follow REST conventions
- Map `_id` to `id` across all endpoints
- Add pagination envelope to search response (`data`, `total`, `limit`)
- Hide OpenSearch internals from API consumers