### PR TITLE
🐛(docker) skip OpenSearch connection during Docker build

### DIFF
--- a/src/backend/core/apps.py
+++ b/src/backend/core/apps.py
@@ -1,5 +1,6 @@
 """Find Core application"""
 
+import os
 import sys
 
 from django.apps import AppConfig
@@ -16,6 +17,10 @@ class CoreConfig(AppConfig):
 
     def ready(self):
         if "pytest" in sys.modules:
+            return
+
+        # Skip OpenSearch initialization during Docker build (collectstatic, etc.)
+        if os.environ.get("DJANGO_CONFIGURATION") == "Build":
             return
 
         from .services.indexing import ensure_index_exists


### PR DESCRIPTION
The core app's ready() method calls ensure_index_exists() which attempts to connect to OpenSearch. This caused Docker builds to require a running OpenSearch instance during collectstatic.

Skip OpenSearch initialization when DJANGO_CONFIGURATION=Build.