### PR TITLE
📦(helm) add support for specifying an existing secretName

### DIFF
--- a/src/helm/find/Chart.yaml
+++ b/src/helm/find/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: find
-version: 0.0.3
+version: 0.0.4

--- a/src/helm/find/README.md
+++ b/src/helm/find/README.md
@@ -21,6 +21,7 @@
 | `ingress.path`                             | Path to use for the Ingress                          | `/`                    |
 | `ingress.hosts`                            | Additional host to configure for the Ingress         | `[]`                   |
 | `ingress.tls.enabled`                      | Whether to enable TLS for the Ingress                | `true`                 |
+| `ingress.tls.secretName`                   | Secret name for TLS config                           | `nil`                  |
 | `ingress.tls.additional[].secretName`      | Secret name for additional TLS config                |                        |
 | `ingress.tls.additional[].hosts[]`         | Hosts for additional TLS config                      |                        |
 | `ingress.customBackends`                   | Add custom backends to ingress                       | `[]`                   |

--- a/src/helm/find/templates/ingress.yaml
+++ b/src/helm/find/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     {{- if .Values.ingress.host }}
-    - secretName: {{ $fullName }}-tls
+    - secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
       hosts:
         - {{ .Values.ingress.host | quote }}
     {{- end }}

--- a/src/helm/find/values.yaml
+++ b/src/helm/find/values.yaml
@@ -38,11 +38,13 @@ ingress:
   hosts: []
   #  - chart-example.local
   ## @param ingress.tls.enabled Whether to enable TLS for the Ingress
+  ## @param ingress.tls.secretName Secret name for TLS config
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingress.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    secretName: null
     additional: []
 
   ## @param ingress.customBackends Add custom backends to ingress


### PR DESCRIPTION
### Purpose
This pull request adds support for specifying a custom `secretName` within the Ingress configuration. This update makes the `find` chart consistent with how TLS secrets are handled across other La Suite numérique Helm charts.

* **Behavior Context:** This configuration alignment follows the convention outlined in the docs helm chart [README.md](https://github.com/suitenumerique/docs/blob/main/src/helm/impress/README.md) under `ingress.tls.secretName`.
* **Code Reference:** The default/override logic is lifted directly from the docs helm chart [here](https://github.com/suitenumerique/docs/blob/24d58a1aa5e88402c14220e1f98a21bc96fd1986/src/helm/impress/templates/ingress.yaml#L32).

### Proposal
* Update `templates/ingress.yaml` to prioritize `.Values.ingress.tls.secretName` if provided, falling back to `{{ $fullName }}-tls` by default.
* Add `ingress.tls.secretName: null` to `values.yaml` for clear user visibility.
* Update the find helm chart README.md.
* Bump helm chart version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new TLS secret name setting for the app’s main Ingress, with a sensible default when not specified.
* **Documentation**
  * Updated the Helm chart documentation to include the new TLS secret name option.
* **Chores**
  * Bumped the Helm chart version to `0.0.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->