### PR TITLE
🔒️(logging) redact sensitive data from logs and harden sentry

### DIFF
--- a/src/backend/core/authentication.py
+++ b/src/backend/core/authentication.py
@@ -69,8 +69,8 @@ class FinderResourceServerBackend(ResourceServerBackend):
     def __init__(self):
         try:
             super().__init__()
-        except Exception as e:
-            logger.error(e)
+        except Exception:
+            logger.exception("Failed to initialize OIDC resource server backend")
             raise
 
         self.UserModel = ResourceUser

--- a/src/backend/core/log_redaction.py
+++ b/src/backend/core/log_redaction.py
@@ -1,0 +1,13 @@
+"""Helpers for scrubbing sensitive data from log records."""
+
+import hashlib
+
+
+def redact_search_query(q: str) -> str:
+    """Return a length-and-hash summary that is safe to log.
+
+    Uses SHA-256 truncated to 8 hex chars: irreversible for non-trivial inputs,
+    deterministic so identical queries correlate across log lines.
+    """
+    digest = hashlib.sha256(q.encode("utf-8")).hexdigest()[:8]
+    return f"len={len(q)} hash={digest}"

--- a/src/backend/core/services/search.py
+++ b/src/backend/core/services/search.py
@@ -5,6 +5,7 @@ import logging
 from django.conf import settings
 
 from core import enums
+from core.log_redaction import redact_search_query
 
 from .opensearch import opensearch_client
 
@@ -78,7 +79,7 @@ def get_query(  # noqa : PLR0913
             },
         }
 
-    logger.info("Performing full-text search: %s", q)
+    logger.info("Performing full-text search: %s", redact_search_query(q))
     return get_full_text_query(q, filter_)
 
 

--- a/src/backend/core/tests/test_api_search_logging.py
+++ b/src/backend/core/tests/test_api_search_logging.py
@@ -1,0 +1,139 @@
+"""Tests for search API logging and redaction."""
+
+import logging
+import re
+from unittest.mock import patch
+
+import pytest
+import responses
+from rest_framework.test import APIClient
+
+from .utils import build_authorization_bearer, setup_oicd_resource_server
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.django_db
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def authenticated_client():
+    """Return an authenticated API client."""
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {build_authorization_bearer()}")
+    return client
+
+
+@responses.activate
+@patch("core.views.search")
+def test_search_view_does_not_log_raw_query(
+    mock_search, caplog, authenticated_client, settings
+):
+    """Search endpoint should not log the raw query string."""
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+
+    mock_search.return_value = {"hits": {"hits": []}}
+
+    with caplog.at_level(logging.INFO, logger="core.views"):
+        response = authenticated_client.post(
+            "/api/v1.0/documents/search/",
+            {"q": "leak_token_xyz"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+
+    for record in caplog.records:
+        assert "leak_token_xyz" not in record.message
+
+    found_redacted = False
+    for record in caplog.records:
+        if "len=" in record.message and "hash=" in record.message:
+            found_redacted = True
+            break
+    assert found_redacted, "Expected redacted query format in logs"
+
+
+@responses.activate
+@patch("core.views.search")
+def test_search_view_logs_redacted_query_format(
+    mock_search, caplog, authenticated_client, settings
+):
+    """Search endpoint should log query in redacted format.
+
+    Expected format: 'Search query=len=X hash=XXXXXXXX on index'
+    """
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+
+    mock_search.return_value = {"hits": {"hits": []}}
+
+    with caplog.at_level(logging.INFO, logger="core.views"):
+        response = authenticated_client.post(
+            "/api/v1.0/documents/search/",
+            {"q": "test_query"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+
+    pattern = r"Search query=len=\d+ hash=[0-9a-f]{8} on index "
+    found_match = False
+    for record in caplog.records:
+        if re.search(pattern, record.message):
+            found_match = True
+            break
+    assert found_match, f"Expected log matching pattern '{pattern}' in logs"
+
+
+@responses.activate
+@patch("core.views.search")
+def test_search_view_does_not_log_full_results_at_debug(
+    mock_search, caplog, authenticated_client, settings
+):
+    """Search endpoint should not log full result bodies at DEBUG level."""
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+
+    mock_search.return_value = {
+        "hits": {"hits": [{"id": "DOC_BODY_LEAK", "title": "sensitive document"}]}
+    }
+
+    with caplog.at_level(logging.DEBUG, logger="core.views"):
+        response = authenticated_client.post(
+            "/api/v1.0/documents/search/",
+            {"q": "test"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+
+    for record in caplog.records:
+        assert "DOC_BODY_LEAK" not in record.message
+
+
+@responses.activate
+@patch("core.views.search")
+def test_search_view_still_logs_result_count(
+    mock_search, caplog, authenticated_client, settings
+):
+    """Search endpoint should still log the result count at INFO level."""
+    setup_oicd_resource_server(responses, settings, sub="user_sub")
+
+    mock_search.return_value = {"hits": {"hits": [{"id": "doc1", "title": "result"}]}}
+
+    with caplog.at_level(logging.INFO, logger="core.views"):
+        response = authenticated_client.post(
+            "/api/v1.0/documents/search/",
+            {"q": "test"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+
+    pattern = r"found \d+ results"
+    found_match = False
+    for record in caplog.records:
+        if re.search(pattern, record.message):
+            found_match = True
+            break
+    assert found_match, f"Expected log matching pattern '{pattern}' in logs"

--- a/src/backend/core/tests/test_authentication.py
+++ b/src/backend/core/tests/test_authentication.py
@@ -1,0 +1,34 @@
+"""Tests for authentication module"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from core.authentication import FinderResourceServerBackend
+
+pytestmark = pytest.mark.django_db
+
+
+def test_resource_server_backend_init_failure_logs_exception(caplog):
+    """Test that OIDC backend init failure logs exception with proper message"""
+    with caplog.at_level(logging.ERROR, logger="core.authentication"):
+        with patch("core.authentication.ResourceServerBackend.__init__") as mock_init:
+            mock_init.side_effect = Exception("client_id=SECRET token=abc123")
+
+            with pytest.raises(Exception):  # noqa: B017
+                FinderResourceServerBackend()
+
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        msg_list = [r.message for r in error_records]
+        assert len(error_records) == 1, (
+            f"Expected exactly 1 ERROR record, got {len(error_records)}: {msg_list}"
+        )
+
+        assert (
+            error_records[0].message
+            == "Failed to initialize OIDC resource server backend"
+        ), f"Wrong message: {error_records[0].message!r}"
+        assert "client_id=SECRET" not in error_records[0].message
+        assert "token=abc123" not in error_records[0].message
+        assert error_records[0].exc_info is not None

--- a/src/backend/core/tests/test_log_redaction.py
+++ b/src/backend/core/tests/test_log_redaction.py
@@ -1,0 +1,59 @@
+"""Tests for log_redaction module."""
+
+import re
+
+from core.log_redaction import redact_search_query
+
+
+class TestRedactSearchQuery:
+    """Test suite for redact_search_query function."""
+
+    def test_redact_search_query_format(self):
+        r"""Output matches regex ^len=\d+ hash=[0-9a-f]{8}$"""
+        result = redact_search_query("test query")
+        pattern = r"^len=\d+ hash=[0-9a-f]{8}$"
+        assert re.match(pattern, result), (
+            f"Output '{result}' does not match pattern '{pattern}'"
+        )
+
+    def test_redact_search_query_does_not_contain_input(self):
+        """Input john.doe@example.com not in output"""
+        sensitive_input = "john.doe@example.com"
+        result = redact_search_query(sensitive_input)
+        assert sensitive_input not in result, (
+            f"Sensitive input found in output: {result}"
+        )
+
+    def test_redact_search_query_empty_string(self):
+        """No exception raised; output is exactly len=0 hash=e3b0c442"""
+        result = redact_search_query("")
+        assert result == "len=0 hash=e3b0c442", (
+            f"Expected 'len=0 hash=e3b0c442', got '{result}'"
+        )
+
+    def test_redact_search_query_deterministic(self):
+        """redact_search_query("foo") == redact_search_query("foo")"""
+        result1 = redact_search_query("foo")
+        result2 = redact_search_query("foo")
+        assert result1 == result2, f"Non-deterministic: '{result1}' != '{result2}'"
+
+    def test_redact_search_query_different_inputs_differ(self):
+        """redact_search_query("foo") != redact_search_query("bar")"""
+        result_foo = redact_search_query("foo")
+        result_bar = redact_search_query("bar")
+        assert result_foo != result_bar, (
+            f"Different inputs produced same output: {result_foo}"
+        )
+
+    def test_redact_search_query_handles_unicode(self):
+        """Input こんにちは does not raise; output matches format regex"""
+        result = redact_search_query("こんにちは")
+        pattern = r"^len=\d+ hash=[0-9a-f]{8}$"
+        assert re.match(pattern, result), f"Unicode input failed: '{result}'"
+
+    def test_redact_search_query_handles_whitespace(self):
+        """Input '   ' produces len=3 hash=..."""
+        result = redact_search_query("   ")
+        assert result.startswith("len=3 hash="), (
+            f"Whitespace handling failed: '{result}'"
+        )

--- a/src/backend/core/tests/test_services_search_logging.py
+++ b/src/backend/core/tests/test_services_search_logging.py
@@ -1,0 +1,74 @@
+"""Tests for search query redaction in services.search logging."""
+
+import logging
+import re
+
+from core.services.search import get_query
+
+
+class TestGetQueryLogging:
+    """Test that get_query() redacts sensitive search queries in logs."""
+
+    def test_get_query_does_not_log_raw_query_for_full_text(self, caplog):
+        """Full-text search should not log the raw query string."""
+        with caplog.at_level(logging.INFO, logger="core.services.search"):
+            get_query(
+                q="leak_secret_xyz",
+                reach="all",
+                visited=[],
+                user_sub="user123",
+                groups=[],
+                tags=[],
+                path=None,
+            )
+
+        # Assert no record contains the raw secret
+        for record in caplog.records:
+            assert "leak_secret_xyz" not in record.message
+
+        # Assert at least one record contains redaction format (len= and hash=)
+        messages = [r.message for r in caplog.records]
+        assert any("len=" in msg and "hash=" in msg for msg in messages)
+
+    def test_get_query_match_all_log_unchanged(self, caplog):
+        """Wildcard query should log the unchanged match_all message."""
+        with caplog.at_level(logging.INFO, logger="core.services.search"):
+            get_query(
+                q="*",
+                reach="all",
+                visited=[],
+                user_sub="user123",
+                groups=[],
+                tags=[],
+                path=None,
+            )
+
+        # Assert exactly one INFO record with the match_all message
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        msg_list = [r.message for r in info_records]
+        assert len(info_records) == 1, (
+            f"Expected exactly 1 INFO record, got {len(info_records)}: {msg_list}"
+        )
+        assert info_records[0].message == "Performing match_all query", (
+            f"Wrong message: {info_records[0].message!r}"
+        )
+
+    def test_get_query_full_text_log_uses_redaction_format(self, caplog):
+        """Full-text search should log redacted format: len=N hash=XXXXXXXX."""
+        with caplog.at_level(logging.INFO, logger="core.services.search"):
+            get_query(
+                q="someuserquery",
+                reach="all",
+                visited=[],
+                user_sub="user123",
+                groups=[],
+                tags=[],
+                path=None,
+            )
+
+        # Assert at least one record matches the redaction format
+        pattern = r"Performing full-text search: len=\d+ hash=[0-9a-f]{8}"
+        messages = [r.message for r in caplog.records]
+        assert any(re.search(pattern, msg) for msg in messages), (
+            f"No message matched pattern {pattern}. Got: {messages}"
+        )

--- a/src/backend/core/views.py
+++ b/src/backend/core/views.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 
 from . import schemas
 from .authentication import ServiceTokenAuthentication
+from .log_redaction import redact_search_query
 from .permissions import IsAuthAuthenticated
 from .services.indexing import (
     ensure_index_exists,
@@ -341,7 +342,11 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
             logger.error("Validation error: %s", errors)
             raise excpt
 
-        logger.info("Search '%s' on index %s", params.q, settings.OPENSEARCH_INDEX)
+        logger.info(
+            "Search query=%s on index %s",
+            redact_search_query(params.q),
+            settings.OPENSEARCH_INDEX,
+        )
         result = search(
             q=params.q,
             nb_results=params.nb_results,
@@ -356,6 +361,5 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
             path=params.path,
         )["hits"]["hits"]
         logger.info("found %d results", len(result))
-        logger.debug("results %s", result)
 
         return Response(result, status=status.HTTP_200_OK)

--- a/src/backend/find/sentry_scrubber.py
+++ b/src/backend/find/sentry_scrubber.py
@@ -1,0 +1,37 @@
+"""Sentry event scrubbing — strips Authorization headers, request bodies, and
+token-bearing query params before events are sent.
+
+Imported by find.settings.Base.post_setup at module load. MUST NOT import any
+Django module at top-level — only stdlib.
+"""
+
+import re
+from typing import Optional
+
+_TOKEN_PARAM_RE = re.compile(
+    r"(?i)(token|api_?key|access_token|id_token|refresh_token)=[^&]*"
+)
+
+
+def before_send(
+    event: Optional[dict],
+    hint: dict,  # pylint: disable=unused-argument
+) -> Optional[dict]:
+    """Sentry before_send hook. Removes secrets from outgoing events."""
+    if event is None:
+        return None
+    request = event.get("request")
+    if not isinstance(request, dict):
+        return event
+    # Strip Authorization header
+    headers = request.get("headers")
+    if isinstance(headers, dict) and "Authorization" in headers:
+        headers.pop("Authorization", None)
+    # Always replace request.data — multipart-safe
+    if "data" in request:
+        request["data"] = "[Filtered]"
+    # Redact known token-bearing query params (preserves other params)
+    qs = request.get("query_string")
+    if isinstance(qs, str):
+        request["query_string"] = _TOKEN_PARAM_RE.sub(r"\1=[Filtered]", qs)
+    return event

--- a/src/backend/find/settings.py
+++ b/src/backend/find/settings.py
@@ -20,6 +20,9 @@ import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
+
+from find.sentry_scrubber import before_send
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -492,6 +495,23 @@ class Base(Configuration):
                 environment=cls.__name__.lower(),
                 release=get_release(),
                 integrations=[DjangoIntegration()],
+                send_default_pii=False,
+                include_local_variables=False,
+                before_send=before_send,
+                event_scrubber=EventScrubber(
+                    denylist=DEFAULT_DENYLIST
+                    + [
+                        "authorization",
+                        "id_token",
+                        "access_token",
+                        "refresh_token",
+                        "oidc_rp_client_secret",
+                        "oidc_rs_client_secret",
+                        "oidc_rs_private_key_str",
+                        "opensearch_password",
+                    ],
+                    recursive=True,
+                ),
             )
             scope = sentry_sdk.get_current_scope()
             scope.set_extra("application", "backend")

--- a/src/backend/find/tests/test_sentry_scrubber.py
+++ b/src/backend/find/tests/test_sentry_scrubber.py
@@ -1,0 +1,95 @@
+"""Tests for Sentry event scrubbing."""
+
+from find.sentry_scrubber import before_send
+
+
+def test_before_send_returns_none_when_event_is_none():
+    """None events should be passed through."""
+    assert before_send(None, {}) is None
+
+
+def test_before_send_handles_missing_request_key():
+    """Events without request metadata should be unchanged."""
+    event = {}
+
+    assert before_send(event, {}) == event
+
+
+def test_before_send_strips_authorization_header():
+    """Authorization headers should be removed while preserving other headers."""
+    event = {
+        "request": {
+            "headers": {
+                "Authorization": "Bearer abc123",
+                "Content-Type": "application/json",
+            }
+        }
+    }
+
+    result = before_send(event, {})
+
+    assert result is not None
+    assert "Authorization" not in result["request"]["headers"]
+    assert result["request"]["headers"]["Content-Type"] == "application/json"
+
+
+def test_before_send_handles_missing_authorization_header():
+    """Headers without Authorization should be unchanged."""
+    event = {"request": {"headers": {"Content-Type": "application/json"}}}
+
+    assert before_send(event, {}) == event
+
+
+def test_before_send_strips_request_data_unconditionally():
+    """Request bodies should be replaced wholesale."""
+    event = {"request": {"data": {"username": "u", "password": "p"}}}
+
+    result = before_send(event, {})
+
+    assert result is not None
+    assert result["request"]["data"] == "[Filtered]"
+
+
+def test_before_send_strips_request_data_multipart():
+    """Multipart-looking request bodies should also be replaced wholesale."""
+    event = {"request": {"data": {"file": "<file>", "name": "test"}}}
+
+    result = before_send(event, {})
+
+    assert result is not None
+    assert result["request"]["data"] == "[Filtered]"
+
+
+def test_before_send_redacts_token_query_param():
+    """Token-bearing query string values should be redacted only where needed."""
+    event = {"request": {"query_string": "token=abc123&q=search"}}
+
+    result = before_send(event, {})
+
+    assert result is not None
+    assert "q=search" in result["request"]["query_string"]
+    assert "abc123" not in result["request"]["query_string"]
+
+
+def test_before_send_handles_missing_query_string():
+    """Requests without query strings should be unchanged."""
+    event = {"request": {"headers": {}}}
+
+    assert before_send(event, {}) == event
+
+
+def test_before_send_preserves_unrelated_fields():
+    """Unrelated top-level Sentry fields should be preserved."""
+    event = {
+        "request": {},
+        "tags": {"service": "find"},
+        "extra": {"feature": "search"},
+        "level": "error",
+    }
+
+    result = before_send(event, {})
+
+    assert result is not None
+    assert result["tags"] == {"service": "find"}
+    assert result["extra"] == {"feature": "search"}
+    assert result["level"] == "error"


### PR DESCRIPTION
## Purpose

User-supplied search queries and OIDC secrets were reaching application logs and
Sentry events with no scrubbing. Operators tailing logs or anyone with Sentry
access could see plaintext queries (PII), access/refresh tokens, OIDC client
secrets, and `Authorization` headers. This PR closes that gap without changing
external behaviour.
