### PR TITLE
🔒️(logging) avoid logging sensitive search queries and raw exceptions

### DIFF
--- a/src/backend/core/authentication.py
+++ b/src/backend/core/authentication.py
@@ -69,8 +69,8 @@ class FinderResourceServerBackend(ResourceServerBackend):
     def __init__(self):
         try:
             super().__init__()
-        except Exception as e:
-            logger.error(e)
+        except Exception:
+            logger.exception("Failed to initialize OIDC resource server backend")
             raise
 
         self.UserModel = ResourceUser

--- a/src/backend/core/services/search.py
+++ b/src/backend/core/services/search.py
@@ -78,7 +78,7 @@ def get_query(  # noqa : PLR0913
             },
         }
 
-    logger.info("Performing full-text search: %s", q)
+    logger.info("Performing full-text search")
     return get_full_text_query(q, filter_)
 
 

--- a/src/backend/core/views.py
+++ b/src/backend/core/views.py
@@ -341,7 +341,7 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
             logger.error("Validation error: %s", errors)
             raise excpt
 
-        logger.info("Search '%s' on index %s", params.q, settings.OPENSEARCH_INDEX)
+        logger.info("Search on index %s", settings.OPENSEARCH_INDEX)
         result = search(
             q=params.q,
             nb_results=params.nb_results,
@@ -356,6 +356,5 @@ class SearchDocumentView(ResourceServerMixin, views.APIView):
             path=params.path,
         )["hits"]["hits"]
         logger.info("found %d results", len(result))
-        logger.debug("results %s", result)
 
         return Response(result, status=status.HTTP_200_OK)


### PR DESCRIPTION
Stop logging plaintext search queries and raw OIDC init exceptions.