### PR TITLE
🔧(backend) add PostHog Python SDK (opt-in init only)

### DIFF
--- a/src/backend/core/tests/test_settings_posthog.py
+++ b/src/backend/core/tests/test_settings_posthog.py
@@ -1,0 +1,47 @@
+"""Tests for PostHog SDK settings initialization."""
+
+import posthog
+import pytest
+
+from find.settings import Base
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_index():
+    """Shadow the conftest OpenSearch fixture — these tests don't need it."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_posthog_module_state():
+    """Reset posthog module-global state after each test to prevent leakage."""
+    yield
+    posthog.api_key = None
+    posthog.host = None
+
+
+@pytest.mark.parametrize(
+    "env_vars",
+    [
+        {"POSTHOG_API_KEY": "phc_test"},
+        {"POSTHOG_HOST": "https://eu.i.posthog.com"},
+        {"POSTHOG_API_KEY": "", "POSTHOG_HOST": "https://eu.i.posthog.com"},
+        {"POSTHOG_API_KEY": "phc_test", "POSTHOG_HOST": ""},
+    ],
+)
+def test_posthog_stays_disabled_when_partial_config(monkeypatch, env_vars):
+    """PostHog SDK must NOT initialize when config is incomplete."""
+    for key, value in env_vars.items():
+        monkeypatch.setattr(Base, key, value)
+    Base.post_setup()
+    assert posthog.api_key is None
+    assert posthog.host is None
+
+
+def test_posthog_initialized_when_both_set(monkeypatch):
+    """PostHog SDK must initialize when both API key and host are set."""
+    monkeypatch.setattr(Base, "POSTHOG_API_KEY", "phc_test_xyz")
+    monkeypatch.setattr(Base, "POSTHOG_HOST", "https://eu.i.posthog.com")
+    Base.post_setup()
+    assert posthog.api_key == "phc_test_xyz"
+    assert posthog.host == "https://eu.i.posthog.com"

--- a/src/backend/find/settings.py
+++ b/src/backend/find/settings.py
@@ -16,6 +16,7 @@ from socket import gethostbyname, gethostname
 
 from django.utils.translation import gettext_lazy as _
 
+import posthog
 import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -291,6 +292,11 @@ class Base(Configuration):
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN", environ_prefix=None)
 
+    POSTHOG_API_KEY = values.Value(
+        None, environ_name="POSTHOG_API_KEY", environ_prefix=None
+    )
+    POSTHOG_HOST = values.Value(None, environ_name="POSTHOG_HOST", environ_prefix=None)
+
     # Celery
     CELERY_BROKER_URL = values.Value("redis://redis:6379/0")
     CELERY_BROKER_TRANSPORT_OPTIONS = values.DictValue({})
@@ -498,6 +504,11 @@ class Base(Configuration):
 
             # Ignore the logs added by the DockerflowMiddleware
             ignore_logger("request.summary")
+
+        # PostHog Python SDK — opt-in, module-global init mirroring the Sentry pattern.
+        if cls.POSTHOG_API_KEY and cls.POSTHOG_HOST:
+            posthog.api_key = cls.POSTHOG_API_KEY
+            posthog.host = cls.POSTHOG_HOST
 
 
 class Build(Base):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "gunicorn==25.3.0",
   "mozilla-django-oidc==5.0.2",
   "opensearch-py==3.2.0",
+  "posthog==7.18.0",
   "psycopg[binary]==3.3.4",
   "py3langid==0.3.0",
   "pydantic==2.13.4",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -60,6 +60,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "billiard"
 version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -290,6 +299,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "django"
 version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -494,6 +512,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "mozilla-django-oidc" },
     { name = "opensearch-py" },
+    { name = "posthog" },
     { name = "psycopg", extra = ["binary"] },
     { name = "py3langid" },
     { name = "pydantic" },
@@ -546,6 +565,7 @@ requires-dist = [
     { name = "ipython", marker = "extra == 'dev'", specifier = "==9.13.0" },
     { name = "mozilla-django-oidc", specifier = "==5.0.2" },
     { name = "opensearch-py", specifier = "==3.2.0" },
+    { name = "posthog", specifier = "==7.18.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "py3langid", specifier = "==0.3.0" },
     { name = "pydantic", specifier = "==2.13.4" },
@@ -895,6 +915,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/41/d7922b23d9f3dec427286b13f8f15b12c08eea3950a6cfd53979a54aed91/posthog-7.18.0.tar.gz", hash = "sha256:560230cf9616ac1fde5e3bfba1c666ab69e8488e5417005f86f91f7c6ef74252", size = 229913, upload-time = "2026-06-05T13:56:22.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/33/cb300af867a22c5e1680f6d1ebe5242ebe7de8280a82a5759e16211e28ee/posthog-7.18.0-py3-none-any.whl", hash = "sha256:9913586a958e5e81dbb1cdc4d4bedc8f95a268807b17ad03b5c55d2adff55dd7", size = 268498, upload-time = "2026-06-05T13:56:20.855Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the PostHog Python SDK with opt-in initialization only.

We spoke about PostHog in the Weekly Find meeting; implementation only gets priority after production-release.